### PR TITLE
Refine object property access

### DIFF
--- a/LeanCloudTests/ObjectTestCase.swift
+++ b/LeanCloudTests/ObjectTestCase.swift
@@ -136,12 +136,13 @@ class ObjectTestCase: BaseTestCase {
 
         object1.nonDynamicField = "foo"
         XCTAssertEqual(object1.nonDynamicField, "foo")
-        XCTAssertNil(object1["nonDynamicField"])
+        XCTAssertEqual(object1["nonDynamicField"] as? LCString, LCString("foo"))
         XCTAssertFalse(object1.hasDataToUpload)
 
         /* Non-dynamic property cannot record update operation by accessor assignment.
            However, you can use subscript to get things done. */
         object2["nonDynamicField"] = LCString("foo")
+        XCTAssertEqual(object2.nonDynamicField, "foo")
         XCTAssertEqual(object2["nonDynamicField"] as? LCString, LCString("foo"))
         XCTAssertTrue(object2.hasDataToUpload)
     }

--- a/Sources/Storage/DataType/Dictionary.swift
+++ b/Sources/Storage/DataType/Dictionary.swift
@@ -92,7 +92,7 @@ public final class LCDictionary: NSObject, LCValue, LCValueExtension, Collection
         }
     }
 
-    func set(_ key: String, _ value: LCValue) {
+    func set(_ key: String, _ value: LCValue?) {
         self.value[key] = value
     }
 

--- a/Sources/Storage/DataType/Dictionary.swift
+++ b/Sources/Storage/DataType/Dictionary.swift
@@ -92,6 +92,10 @@ public final class LCDictionary: NSObject, LCValue, LCValueExtension, Collection
         }
     }
 
+    func set(_ key: String, _ value: LCValue) {
+        self.value[key] = value
+    }
+
     public var jsonValue: AnyObject {
         return value.mapValue { value in value.jsonValue } as AnyObject
     }

--- a/Sources/Storage/DataType/Object.swift
+++ b/Sources/Storage/DataType/Object.swift
@@ -374,7 +374,7 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
      - returns: The value for key.
      */
     open func get(_ key: String) -> LCValue? {
-        return propertyTable[key]
+        return ObjectProfiler.propertyValue(self, key) ?? propertyTable[key]
     }
 
     /**

--- a/Sources/Storage/DataType/Object.swift
+++ b/Sources/Storage/DataType/Object.swift
@@ -26,9 +26,20 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
     open fileprivate(set) dynamic var updatedAt: LCDate?
 
     /**
-     The table of all properties.
+     The table of properties.
+
+     - note: This property table may not contains all properties, 
+             because when a property did set in initializer, its setter hook will not be called in Swift.
+             This property is intent for internal use.
+             For accesssing all properties, please use `dictionary` property.
      */
-    var propertyTable: LCDictionary = [:]
+    fileprivate var propertyTable: LCDictionary = [:]
+
+    /// The table of all properties.
+    var dictionary: LCDictionary {
+        synchronizePropertyTable()
+        return propertyTable
+    }
 
     var hasObjectId: Bool {
         return objectId != nil
@@ -95,20 +106,7 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
     }
 
     open func encode(with aCoder: NSCoder) {
-        let propertyTable = self.propertyTable.copy() as! LCDictionary
-
-        /* We merge nonnull instance variables into property table here.
-           Because, when a property is set through dot syntax in initializer, the corresponding setter hook will not be called,
-           as a side effect, the property will not be added into property table.
-           If skip this step, the properties that set in initializer will be lost.
-         */
-        ObjectProfiler.iterateProperties(self) { (key, _) in
-            if key == "propertyTable" { return }
-
-            if let instanceVariableValue = Runtime.instanceVariableValue(self, key) as? LCValue {
-                propertyTable[key] = instanceVariableValue
-            }
-        }
+        let propertyTable = self.dictionary.copy() as! LCDictionary
 
         aCoder.encode(propertyTable, forKey: "propertyTable")
     }
@@ -134,11 +132,11 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
     }
 
     open func makeIterator() -> DictionaryIterator<String, LCValue> {
-        return propertyTable.makeIterator()
+        return dictionary.makeIterator()
     }
 
     open var jsonValue: AnyObject {
-        var result = propertyTable.jsonValue as! [String: AnyObject]
+        var result = dictionary.jsonValue as! [String: AnyObject]
 
         result["__type"]    = "Object" as AnyObject?
         result["className"] = actualClassName as AnyObject?
@@ -171,7 +169,7 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
     }
 
     func forEachChild(_ body: (_ child: LCValue) -> Void) {
-        propertyTable.forEachChild(body)
+        dictionary.forEachChild(body)
     }
 
     func add(_ other: LCValue) throws -> LCValue {
@@ -307,6 +305,26 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
         }
 
         didChangeValue(forKey: key)
+    }
+
+    /**
+     Synchronize property table.
+
+     This method will synchronize nonnull instance variables into property table.
+
+     Q: Why we need this method?
+
+     A: When a property is set through dot syntax in initializer, its corresponding setter hook will not be called,
+        it will result in that some properties will not be added into property table.
+     */
+    func synchronizePropertyTable() {
+        ObjectProfiler.iterateProperties(self) { (key, _) in
+            if key == "propertyTable" { return }
+
+            if let value = Runtime.instanceVariableValue(self, key) as? LCValue {
+                propertyTable.set(key, value)
+            }
+        }
     }
 
     /**

--- a/Sources/Storage/DataType/Object.swift
+++ b/Sources/Storage/DataType/Object.swift
@@ -36,10 +36,10 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
     fileprivate var propertyTable: LCDictionary = [:]
 
     /// The table of all properties.
-    var dictionary: LCDictionary {
-        synchronizePropertyTable()
-        return propertyTable
-    }
+    lazy var dictionary: LCDictionary = {
+        self.synchronizePropertyTable()
+        return self.propertyTable
+    }()
 
     var hasObjectId: Bool {
         return objectId != nil

--- a/Sources/Storage/Engine.swift
+++ b/Sources/Storage/Engine.swift
@@ -62,7 +62,7 @@ public final class LCEngine {
      - returns: The result of function all.
      */
     public static func call(_ function: String, parameters: LCObject) -> LCOptionalResult {
-        return call(function, parameters: parameters.propertyTable)
+        return call(function, parameters: parameters.dictionary)
     }
 
     /**

--- a/Sources/Storage/ObjectProfiler.swift
+++ b/Sources/Storage/ObjectProfiler.swift
@@ -141,7 +141,7 @@ class ObjectProfiler {
 
      - returns: Concrete LCValue subclass, or nil if property type is not LCValue.
      */
-    static func getLCValue(object: LCObject, propertyName: String) -> LCValue.Type? {
+    static func getLCValue(_ object: LCObject, _ propertyName: String) -> LCValue.Type? {
         let property = class_getProperty(object_getClass(object), propertyName)
 
         if property != nil {
@@ -675,7 +675,7 @@ class ObjectProfiler {
         let key = ObjectProfiler.propertyName(cmd)
         let value = value as? LCValue
 
-        if ObjectProfiler.getLCValue(object: object, propertyName: key) == nil {
+        if ObjectProfiler.getLCValue(object, key) == nil {
             object.set(key.firstLowercaseString, value: value)
         } else {
             object.set(key, value: value)

--- a/Sources/Storage/ObjectProfiler.swift
+++ b/Sources/Storage/ObjectProfiler.swift
@@ -152,6 +152,18 @@ class ObjectProfiler {
     }
 
     /**
+     Check if object has a property of type LCValue for given name.
+
+     - parameter object:       Target object.
+     - parameter propertyName: The name of property to be inspected.
+
+     - returns: true if object has a property of type LCValue for given name, false otherwise.
+     */
+    static func hasLCValue(_ object: LCObject, _ propertyName: String) -> Bool {
+        return getLCValue(object, propertyName) != nil
+    }
+
+    /**
      Synthesize a single property for class.
 
      - parameter property: Property which to be synthesized.
@@ -586,6 +598,20 @@ class ObjectProfiler {
         return propertyName
     }
 
+    /**
+     Get property value for given name from an object.
+
+     - parameter object:       The object that owns the property.
+     - parameter propertyName: The property name.
+
+     - returns: The property value, or nil if such a property not found.
+     */
+    static func propertyValue(_ object: LCObject, _ propertyName: String) -> LCValue? {
+        guard hasLCValue(object, propertyName) else { return nil }
+
+        return Runtime.instanceVariableValue(object, propertyName) as? LCValue
+    }
+
     static func getJSONString(_ object: LCValue) -> String {
         return getJSONString(object, depth: 0)
     }
@@ -664,7 +690,7 @@ class ObjectProfiler {
     static let propertyGetter: @convention(c) (LCObject, Selector) -> AnyObject? = {
         (object: LCObject, cmd: Selector) -> AnyObject? in
         let key = NSStringFromSelector(cmd)
-        return Runtime.instanceVariableValue(object, key) ?? object.get(key)
+        return object.get(key)
     }
 
     /**

--- a/Sources/Storage/ObjectProfiler.swift
+++ b/Sources/Storage/ObjectProfiler.swift
@@ -663,7 +663,7 @@ class ObjectProfiler {
                 return "{\n\(bodyIndent)\(body)\n\(lastIndent)}"
             }
         case let object as LCObject:
-            let dictionary = object.propertyTable.copy() as! LCDictionary
+            let dictionary = object.dictionary.copy() as! LCDictionary
 
             dictionary["__type"]    = LCString("Object")
             dictionary["className"] = LCString(object.actualClassName)

--- a/Sources/Storage/Operation.swift
+++ b/Sources/Storage/Operation.swift
@@ -178,7 +178,7 @@ class OperationHub {
      */
     func operationReducerType(_ operation: Operation) -> OperationReducer.Type? {
         let propertyName = operation.key
-        let propertyType = ObjectProfiler.getLCValue(object: object, propertyName: propertyName)
+        let propertyType = ObjectProfiler.getLCValue(object, propertyName)
 
         if let propertyType = propertyType {
             return Operation.reducerType(propertyType)


### PR DESCRIPTION
改进对象的属性访问，确保在保存对象时，在构造方法中设置的属性不会漏掉。