### PR TITLE
Fix crash for identity test between non-equatable types

### DIFF
--- a/Sources/Storage/Runtime.swift
+++ b/Sources/Storage/Runtime.swift
@@ -25,7 +25,9 @@ class Runtime {
         var eachSubclass: AnyClass! = subclass
 
         while let eachSuperclass = class_getSuperclass(eachSubclass) {
-            if eachSuperclass === superclass {
+            /* Use ObjectIdentifier instead of `===` to make identity test.
+               Because some types cannot respond to `===`, like WKObject in WebKit framework. */
+            if ObjectIdentifier(eachSuperclass) == ObjectIdentifier(superclass) {
                 return true
             }
             eachSubclass = eachSuperclass


### PR DESCRIPTION
修复对类型进行相等性比较时 crash 的问题。导致问题的原因是应用引入了不可比较类型。例如 WebKit.framework 中的 WKObject 类型无法响应 `===` 运算符。修复方案是利用 ObjectIdentifier 进行比较。

@leancloud/ios-group @aisk 