### PR TITLE
Make object mutable after unarchiving

### DIFF
--- a/LeanCloudTests/TypeTestCase.swift
+++ b/LeanCloudTests/TypeTestCase.swift
@@ -123,6 +123,9 @@ class TypeTestCase: BaseTestCase {
         let relationCopy = objectCopy.relationForKey("friend")
         XCTAssertEqual(relationCopy.value, relation.value)
 
+        /* Test mutability after unarchiving. */
+        objectCopy["foo"] = "bar" as LCString
+
         let string = LCString("foo")
         let stringCopy = archiveThenUnarchive(string)
         XCTAssertEqual(stringCopy, string)

--- a/Sources/Storage/DataType/Object.swift
+++ b/Sources/Storage/DataType/Object.swift
@@ -96,8 +96,8 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
         }
     }
 
-    public required init?(coder aDecoder: NSCoder) {
-        super.init()
+    public required convenience init?(coder aDecoder: NSCoder) {
+        self.init()
         propertyTable = (aDecoder.decodeObject(forKey: "propertyTable") as? LCDictionary) ?? [:]
 
         propertyTable.forEach { (key, value) in


### PR DESCRIPTION
Make decoding initializer to call designated initializer to ensure complete initialization.

Refer to https://forum.leancloud.cn/t/swift-currentuser/14895

@leancloud/ios-group @BinaryHB 