### PR TITLE
Only register built-in object classes.

### DIFF
--- a/LeanCloudTests/BaseTestCase.swift
+++ b/LeanCloudTests/BaseTestCase.swift
@@ -31,6 +31,9 @@ class BaseTestCase: XCTestCase {
     
     override func setUp() {
         super.setUp()
+
+        TestObject.register()
+
         /* App name is "iOS SDK UnitTest". */
         LeanCloud.initialize(
             applicationID:  "nq0awk3lh1dpmbkziz54377mryii8ny4xvp6njoygle5nlyg",

--- a/Sources/Storage/ObjectProfiler.swift
+++ b/Sources/Storage/ObjectProfiler.swift
@@ -68,15 +68,12 @@ class ObjectProfiler {
              subclass will be registered for the class name.
      */
     static func registerClasses() {
-        var classes = [LCObject.self]
-        let subclasses = Runtime.subclasses(LCObject.self) as! [LCObject.Type]
+        /* Only register builtin classes. */
+        let builtinClasses = [LCObject.self, LCRole.self, LCUser.self]
 
-        classes.append(contentsOf: subclasses)
-
-        /* Sort classes to make sure subclass will be registered after superclass. */
-        classes = Runtime.toposort(classes: classes) as! [LCObject.Type]
-
-        classes.forEach { registerClass($0) }
+        builtinClasses.forEach { type in
+            type.register()
+        }
     }
 
     /**


### PR DESCRIPTION
只注册内置的对象类型。这个改动要求开发者手动注册 object 类型，而不是 SDK 扫描应用中所有的类型来自动注册。做这个改动的原因是在模拟器中偶尔会崩溃，崩溃是因为 inspect 某个类时出现了 bad access，但不清楚造成 bad access 的具体原因。 @zapcannon87 