### PR TITLE
Add test cases for request cancellation.

### DIFF
--- a/LeanCloudTests/BaseTestCase.swift
+++ b/LeanCloudTests/BaseTestCase.swift
@@ -40,5 +40,12 @@ class BaseTestCase: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
+    func busywait(interval: TimeInterval = 0.1, untilTrue: () -> Bool) -> Void {
+        while !untilTrue() {
+            let due = Date(timeIntervalSinceNow: interval)
+            RunLoop.current.run(mode: .defaultRunLoopMode, before: due)
+        }
+    }
+
 }


### PR DESCRIPTION
添加了取消网络请求的测试用例。

@zapcannon87 @leancloud/sdk-only 