### PR TITLE
Cache app router to file system.

### DIFF
--- a/LeanCloud.xcodeproj/project.pbxproj
+++ b/LeanCloud.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		116A682621427442004141A5 /* RouterTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116A682521427442004141A5 /* RouterTestCase.swift */; };
 		1178D10F213F7B9600429131 /* APITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178D10E213F7B9600429131 /* APITestCase.swift */; };
 		1178D132214019F800429131 /* HTTPRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1178D131214019F800429131 /* HTTPRouter.swift */; };
+		11A166CD214F57360094AF13 /* LocalStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A166CC214F57360094AF13 /* LocalStorage.swift */; };
+		11A166DE214F5E440094AF13 /* PersistentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A166DD214F5E440094AF13 /* PersistentController.swift */; };
+		11A166E221509F020094AF13 /* AppRouterCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A166E121509F020094AF13 /* AppRouterCache.swift */; };
+		11A166E82150A39F0094AF13 /* AppRouterCache.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 11A166E62150A39F0094AF13 /* AppRouterCache.xcdatamodeld */; };
 		11CD228B213545A1007E270A /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11CD228A213545A1007E270A /* Application.swift */; };
 		8334561C1CE589E500D42725 /* EngineTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8334561B1CE589E500D42725 /* EngineTestCase.swift */; };
 		8342FCC61C7B13A700C3CF15 /* LeanCloud.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8342FCBB1C7B13A700C3CF15 /* LeanCloud.framework */; };
@@ -121,6 +125,10 @@
 		116A682521427442004141A5 /* RouterTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterTestCase.swift; sourceTree = "<group>"; };
 		1178D10E213F7B9600429131 /* APITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITestCase.swift; sourceTree = "<group>"; };
 		1178D131214019F800429131 /* HTTPRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRouter.swift; sourceTree = "<group>"; };
+		11A166CC214F57360094AF13 /* LocalStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorage.swift; sourceTree = "<group>"; };
+		11A166DD214F5E440094AF13 /* PersistentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentController.swift; sourceTree = "<group>"; };
+		11A166E121509F020094AF13 /* AppRouterCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppRouterCache.swift; sourceTree = "<group>"; };
+		11A166E72150A39F0094AF13 /* AppRouterCache.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AppRouterCache.xcdatamodel; sourceTree = "<group>"; };
 		11CD228A213545A1007E270A /* Application.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		8334561B1CE589E500D42725 /* EngineTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EngineTestCase.swift; sourceTree = "<group>"; };
 		8342FCBB1C7B13A700C3CF15 /* LeanCloud.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LeanCloud.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -193,6 +201,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		11A166CB214F56F00094AF13 /* LocalStorage */ = {
+			isa = PBXGroup;
+			children = (
+				11A166CC214F57360094AF13 /* LocalStorage.swift */,
+				11A166DD214F5E440094AF13 /* PersistentController.swift */,
+			);
+			path = LocalStorage;
+			sourceTree = "<group>";
+		};
 		8342FCB11C7B13A600C3CF15 = {
 			isa = PBXGroup;
 			children = (
@@ -244,6 +261,7 @@
 			isa = PBXGroup;
 			children = (
 				835F5D401D7E6808004D1A0E /* Storage */,
+				11A166CB214F56F00094AF13 /* LocalStorage */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -263,6 +281,8 @@
 				83B4DB221DB8618A00E36067 /* Logger.swift */,
 				835F5D601D7E6808004D1A0E /* HTTPClient.swift */,
 				1178D131214019F800429131 /* HTTPRouter.swift */,
+				11A166E121509F020094AF13 /* AppRouterCache.swift */,
+				11A166E62150A39F0094AF13 /* AppRouterCache.xcdatamodeld */,
 				835F5D5C1D7E6808004D1A0E /* Operation.swift */,
 				835F5D5A1D7E6808004D1A0E /* ObjectProfiler.swift */,
 				835F5D5B1D7E6808004D1A0E /* ObjectUpdater.swift */,
@@ -496,6 +516,7 @@
 				835F5D6A1D7E6808004D1A0E /* Array.swift in Sources */,
 				835F5D731D7E6808004D1A0E /* Relation.swift in Sources */,
 				835F5D6D1D7E6808004D1A0E /* Date.swift in Sources */,
+				11A166DE214F5E440094AF13 /* PersistentController.swift in Sources */,
 				835F5D881D7E6808004D1A0E /* Value.swift in Sources */,
 				835F5D6F1D7E6808004D1A0E /* GeoPoint.swift in Sources */,
 				835F5D841D7E6808004D1A0E /* Result.swift in Sources */,
@@ -507,12 +528,14 @@
 				835F5D711D7E6808004D1A0E /* Number.swift in Sources */,
 				835F5D871D7E6808004D1A0E /* Utility.swift in Sources */,
 				835F5D7F1D7E6808004D1A0E /* Operation.swift in Sources */,
+				11A166CD214F57360094AF13 /* LocalStorage.swift in Sources */,
 				835F5D661D7E6808004D1A0E /* BatchRequest.swift in Sources */,
 				835F5D851D7E6808004D1A0E /* Runtime.swift in Sources */,
 				835F5D721D7E6808004D1A0E /* Object.swift in Sources */,
 				1178D132214019F800429131 /* HTTPRouter.swift in Sources */,
 				835F5D811D7E6808004D1A0E /* Request.swift in Sources */,
 				835F5D681D7E6808004D1A0E /* CQLClient.swift in Sources */,
+				11A166E82150A39F0094AF13 /* AppRouterCache.xcdatamodeld in Sources */,
 				835F5D791D7E6808004D1A0E /* Extension.swift in Sources */,
 				835F5D7D1D7E6808004D1A0E /* ObjectProfiler.swift in Sources */,
 				835F5D821D7E6808004D1A0E /* Response.swift in Sources */,
@@ -525,6 +548,7 @@
 				835F5D751D7E6808004D1A0E /* String.swift in Sources */,
 				835F5D7B1D7E6808004D1A0E /* LeanCloud.swift in Sources */,
 				835F5D741D7E6808004D1A0E /* Role.swift in Sources */,
+				11A166E221509F020094AF13 /* AppRouterCache.swift in Sources */,
 				835F5D781D7E6808004D1A0E /* Error.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -678,7 +702,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LeanCloud/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.leancloud.LeanCloud;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -700,7 +724,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LeanCloud/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.leancloud.LeanCloud;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -715,6 +739,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LeanCloudTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.leancloud.LeanCloudTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -729,6 +754,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LeanCloudTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = cn.leancloud.LeanCloudTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -769,6 +795,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		11A166E62150A39F0094AF13 /* AppRouterCache.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				11A166E72150A39F0094AF13 /* AppRouterCache.xcdatamodel */,
+			);
+			currentVersion = 11A166E72150A39F0094AF13 /* AppRouterCache.xcdatamodel */;
+			path = AppRouterCache.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 8342FCB21C7B13A600C3CF15 /* Project object */;
 }

--- a/LeanCloudTests/RouterTestCase.swift
+++ b/LeanCloudTests/RouterTestCase.swift
@@ -77,19 +77,20 @@ class RouterTestCase: BaseTestCase {
     }
 
     func testCacheExpiration() {
-        let dictionary = LCDictionary(unsafeObject: [
-            "ttl" : 0.3 as AnyObject
-        ])
+        let host = "s5vdi3ie.api.lncld.net"
+        let appRouterCache = AppRouterCache(application: cnApplication)
 
-        let cache = try! HTTPRouter.Cache(dictionary: dictionary)
+        do {
+            try appRouterCache.cacheHostTable([.api: host], expirationDate: Date(timeIntervalSinceNow: 0.3))
+        } catch let error {
+            XCTFail(error.localizedDescription)
+        }
 
-        Thread.sleep(forTimeInterval: 0.2)
+        XCTAssertEqual(try appRouterCache.fetchHost(module: .api), host)
+        XCTAssertEqual(try appRouterCache.fetchHost(module: .push), nil)
 
-        XCTAssertFalse(cache.isExpired)
-
-        Thread.sleep(forTimeInterval: 0.2)
-
-        XCTAssertTrue(cache.isExpired)
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertEqual(try appRouterCache.fetchHost(module: .api), nil)
     }
 
     func testAppRouterThrottle() {

--- a/Sources/LocalStorage/LocalStorage.swift
+++ b/Sources/LocalStorage/LocalStorage.swift
@@ -1,0 +1,325 @@
+//
+//  LocalStorage.swift
+//  LeanCloud
+//
+//  Created by Tianyong Tang on 2018/9/17.
+//  Copyright © 2018 LeanCloud. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+/**
+ Local storage.
+
+ This type defines a local storage backed by Core Data.
+ */
+class LocalStorage {
+
+    /// The application of local storage.
+    let application: LCApplication
+
+    /**
+     Initialize local storage with application.
+
+     - parameter application: The LeanCloud application.
+     */
+    init(application: LCApplication) {
+        self.application = application
+    }
+
+    /// The global lock for all local storages.
+    private static let lock = NSRecursiveLock()
+
+    /// The lock for current local storage.
+    private let lock: NSRecursiveLock = LocalStorage.lock
+
+    /// The Storage name
+    private var name: String? {
+        return (self as? LocalStorageProtocol)?.name
+    }
+
+    /// The Storage type
+    private var type: LocalStorageType? {
+        return (self as? LocalStorageProtocol)?.type
+    }
+
+    /// This error indicates that it cannot find a file system location to store data.
+    private lazy var locationNotFound = LCError(code: .notFound, reason: "Storage location not found.")
+
+    /// The managed object context.
+    private var managedObjectContext: NSManagedObjectContext?
+
+    /**
+     Load managed object context.
+     */
+    private func loadManagedObjectContext() throws -> NSManagedObjectContext {
+        return try synchronize(on: self) {
+            if let managedObjectContext = self.managedObjectContext {
+                return managedObjectContext
+            }
+
+            guard let name = name else {
+                throw LCError(code: .inconsistency, reason: "Unknown local storage name.")
+            }
+
+            let bundle = Bundle(for: Swift.type(of: self))
+
+            let persistentStoreType  = try synthesizePersistentStoreType()
+            let persistentController = try PersistentController(name: name, bundle: bundle, type: persistentStoreType)
+            let managedObjectContext = try persistentController.createManagedObjectContext()
+
+            self.managedObjectContext = managedObjectContext
+
+            return managedObjectContext
+        }
+    }
+
+    /// System cache directory.
+    private var systemCacheDirectory: URL? {
+        do {
+            return try FileManager.default.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        } catch let error {
+            Logger.shared.error(error)
+            return nil
+        }
+    }
+
+    /// System application support directory.
+    private var systemApplicationSupportDirectory: URL? {
+        do {
+            return try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        } catch let error {
+            Logger.shared.error(error)
+            return nil
+        }
+    }
+
+    /**
+     Prepare storage file based on a system directory.
+
+     It will create directory if needed.
+
+     - parameter systemDirectory: The system directory.
+
+     - returns: An URL of store file, or nil if it cannot prepare file for some reasons.
+     */
+    private func prepareFile(based systemDirectory: URL?) -> URL? {
+        guard
+            let storageName = name,
+            let applicationID = application.id,
+            let systemDirectory = systemDirectory
+        else {
+            return nil
+        }
+
+        let directory = systemDirectory
+            .appendingPathComponent("LeanCloud")
+            .appendingPathComponent(applicationID.md5String)
+            .appendingPathComponent(storageName)
+
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        } catch let error {
+            Logger.shared.error(error)
+            return nil
+        }
+
+        let url = directory
+            .appendingPathComponent(storageName)
+            .appendingPathExtension("sqlite")
+
+        return url
+    }
+
+    /**
+     Prepare a file which may be cleared by OS.
+     */
+    private func prepareCacheFile() -> URL? {
+        return prepareFile(based: systemCacheDirectory)
+    }
+
+    /**
+     Prepare a file which will not be cleared by OS.
+     */
+    private func preparePersistentFile() -> URL? {
+        return prepareFile(based: systemApplicationSupportDirectory)
+    }
+
+    /**
+     Synthesize a persistent store type.
+     */
+    private func synthesizePersistentStoreType() throws -> PersistentStoreType {
+        guard let type = type else {
+            throw LCError(code: .inconsistency, reason: "Unknown local storage type.")
+        }
+
+        var persistentStoreType: PersistentStoreType
+
+        switch type {
+        case .memory:
+            persistentStoreType = .memory
+        case .fileCache:
+            if let url = prepareCacheFile() {
+                persistentStoreType = .file(url: url)
+            } else {
+                throw locationNotFound
+            }
+        case .fileCacheOrMemory:
+            if let url = prepareCacheFile() {
+                persistentStoreType = .file(url: url)
+            } else {
+                return .memory /* Fallback to memory. */
+            }
+        case .filePersistent:
+            if let url = preparePersistentFile() {
+                persistentStoreType = .file(url: url)
+            } else {
+                throw locationNotFound
+            }
+        }
+
+        return persistentStoreType
+    }
+
+    @discardableResult
+    func perform<T>(block: (NSManagedObjectContext) throws -> T) throws -> T {
+        lock.lock()
+
+        defer {
+            lock.unlock()
+        }
+
+        let managedObjectContext = try loadManagedObjectContext()
+
+        var error: Error?
+        var result: T!
+
+        managedObjectContext.performAndWait {
+            do {
+                result = try block(managedObjectContext)
+            } catch let anError {
+                error = anError
+            }
+        }
+
+        if let error = error {
+            throw error
+        }
+
+        return result
+    }
+
+    /**
+     Create an object.
+     */
+    func createObject<T: NSManagedObject>() throws -> T {
+        return try perform { context in
+            let object = T(context: context)
+            return object
+        }
+    }
+
+    /**
+     Create a singleton object.
+     */
+    func createSingleton<T: NSManagedObject>() throws -> T {
+        return try perform { context in
+            if let object: T = try fetchAnyObject() {
+                return object
+            }
+            let object: T = try createObject()
+            return object
+        }
+    }
+
+    /**
+     Fetch only one object with optional predicate.
+     */
+    func fetchAnyObject<T: NSManagedObject>(predicate: NSPredicate? = nil) throws -> T? {
+        return try perform { context in
+            let fetchRequest = T.fetchRequest() as! NSFetchRequest<T>
+            fetchRequest.fetchLimit = 1
+            fetchRequest.predicate = predicate
+            let result = try context.fetch(fetchRequest)
+            return result.first
+        }
+    }
+
+    /**
+     Delete all objects of a given type.
+     */
+    func deleteAllObjects<T: NSManagedObject>(type: T.Type) throws {
+        try perform { context in
+            let isInMemoryStore = (context.persistentStoreCoordinator?.persistentStores.first { $0.type == NSInMemoryStoreType }) != nil
+
+            /*
+             In-memory store does not support batch delete, We have to delete one by one.
+             */
+            if isInMemoryStore {
+                let fetchRequest = T.fetchRequest() as! NSFetchRequest<T>
+
+                fetchRequest.includesPropertyValues = false /* Only fetch objectID to reduce memory overhead. */
+
+                let objects = try context.fetch(fetchRequest)
+
+                objects.forEach { object in
+                    context.delete(object)
+                }
+            } else {
+                guard let entityName = T.entity().name else {
+                    throw LCError(code: .inconsistency, reason: "Unknown entity name.")
+                }
+
+                let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+
+                try context.execute(deleteRequest)
+            }
+        }
+    }
+
+    /**
+     Save current local storage.
+     */
+    func save() throws {
+        try perform { context in
+            try context.save()
+        }
+    }
+
+}
+
+/**
+ Local storage types.
+ */
+enum LocalStorageType {
+
+    /// This type indicates that data will be stored in memory.
+    case memory
+
+    /// This type indicates that data will be stored in a file, but the file may be cleared by OS.
+    case fileCache
+
+    /// Like fileCache, except that it will fallback to memory store if file cache unavailable.
+    case fileCacheOrMemory
+
+    /// This type indicates that data will be stored in a file, the file will not be cleared by OS.
+    case filePersistent
+
+}
+
+/**
+ Local storage protocol.
+
+ Concrete local storage must confirm this protocol.
+ */
+protocol LocalStorageProtocol {
+
+    /// The name of data model.
+    var name: String { get }
+
+    /// Local storage type.
+    var type: LocalStorageType { get }
+
+}

--- a/Sources/LocalStorage/PersistentController.swift
+++ b/Sources/LocalStorage/PersistentController.swift
@@ -1,0 +1,77 @@
+//
+//  PersistentController.swift
+//  LeanCloud
+//
+//  Created by Tianyong Tang on 2018/9/17.
+//  Copyright © 2018 LeanCloud. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+enum PersistentStoreType {
+
+    case memory
+
+    case file(url: URL)
+
+}
+
+class PersistentController {
+
+    let name: String
+
+    let bundle: Bundle
+
+    let managedObjectModel: NSManagedObjectModel
+
+    let type: PersistentStoreType
+
+    /**
+     Initialize persistent manager.
+
+     - parameter name: The name of the NSPersistentContainer object.
+     - parameter storeType: The store type.
+     */
+    init(name: String, bundle: Bundle, type: PersistentStoreType) throws {
+        guard let momdFile = bundle.url(forResource: name, withExtension: "momd") else {
+            throw LCError(code: .inconsistency, reason: "Failed to locate momd file.")
+        }
+        guard let managedObjectModel = NSManagedObjectModel(contentsOf: momdFile) else {
+            throw LCError(code: .inconsistency, reason: "Failed to create object model from momd file.")
+        }
+
+        self.name = name
+        self.bundle = bundle
+        self.managedObjectModel = managedObjectModel
+        self.type = type
+    }
+
+    /**
+     Create managed object context.
+     */
+    func createManagedObjectContext() throws -> NSManagedObjectContext {
+        let options = [
+            NSInferMappingModelAutomaticallyOption: true,
+            NSMigratePersistentStoresAutomaticallyOption: true
+        ]
+
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+
+        switch type {
+        case .memory:
+            try persistentStoreCoordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: options)
+        case .file(let url):
+            try persistentStoreCoordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: url, options: options)
+        }
+
+        let managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+
+        managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
+        managedObjectContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        managedObjectContext.retainsRegisteredObjects = true
+
+        return managedObjectContext
+    }
+
+}

--- a/Sources/Storage/AppRouterCache.swift
+++ b/Sources/Storage/AppRouterCache.swift
@@ -60,6 +60,7 @@ final class AppRouterCache: LocalStorage, LocalStorageProtocol {
             /* If router table expires, clear cache. */
             guard let expirationDate = appRouterTable.expirationDate, Date() < expirationDate else {
                 try deleteAllObjects(type: AppRouterTable.self)
+                try save()
                 return nil
             }
 

--- a/Sources/Storage/AppRouterCache.swift
+++ b/Sources/Storage/AppRouterCache.swift
@@ -1,0 +1,78 @@
+//
+//  AppRouterCache.swift
+//  LeanCloud
+//
+//  Created by Tianyong Tang on 2018/9/17.
+//  Copyright © 2018 LeanCloud. All rights reserved.
+//
+
+import Foundation
+
+/**
+ App router cache.
+ */
+final class AppRouterCache: LocalStorage, LocalStorageProtocol {
+
+    let name = "AppRouterCache"
+
+    var type = LocalStorageType.fileCacheOrMemory
+
+    /**
+     Cache a host table with expiration date.
+
+     - parameter hostTable: The host table indexed by API module.
+     - parameter expirationDate: The date that host table will expires.
+     */
+    func cacheHostTable(_ hostTable: [HTTPRouter.Module: String], expirationDate: Date) throws {
+        try perform { context in
+            try deleteAllObjects(type: AppRouterTable.self)
+
+            let appRouterTable: AppRouterTable = try createSingleton()
+
+            appRouterTable.expirationDate = expirationDate
+
+            hostTable.forEach { (module, host) in
+                let appRouterRecord = AppRouterRecord(context: context)
+
+                appRouterRecord.key = module.key
+                appRouterRecord.value = host
+
+                appRouterRecord.table = appRouterTable
+            }
+
+            try save()
+        }
+    }
+
+    /**
+     Fetch host for given module.
+
+     - parameter module: The API module.
+
+     - returns: The host for given API module, or nil if expired.
+     */
+    func fetchHost(module: HTTPRouter.Module) throws -> String? {
+        return try perform { context in
+            guard let appRouterTable: AppRouterTable = try fetchAnyObject() else {
+                return nil
+            }
+
+            /* If router table expires, clear cache. */
+            guard let expirationDate = appRouterTable.expirationDate, Date() < expirationDate else {
+                try deleteAllObjects(type: AppRouterTable.self)
+                return nil
+            }
+
+            let predicate = NSPredicate(format: "table = %@ and key = %@", argumentArray: [appRouterTable, module.key])
+
+            guard let appRouterRecord: AppRouterRecord = try fetchAnyObject(predicate: predicate) else {
+                return nil
+            }
+
+            let host = appRouterRecord.value
+
+            return host
+        }
+    }
+
+}

--- a/Sources/Storage/AppRouterCache.xcdatamodeld/AppRouterCache.xcdatamodel/contents
+++ b/Sources/Storage/AppRouterCache.xcdatamodeld/AppRouterCache.xcdatamodel/contents
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14135" systemVersion="17E202" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AppRouterRecord" representedClassName="AppRouterRecord" syncable="YES" codeGenerationType="class">
+        <attribute name="key" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="table" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AppRouterTable" inverseName="records" inverseEntity="AppRouterTable" syncable="YES"/>
+    </entity>
+    <entity name="AppRouterTable" representedClassName="AppRouterTable" syncable="YES" codeGenerationType="class">
+        <attribute name="expirationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="records" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AppRouterRecord" inverseName="table" inverseEntity="AppRouterRecord" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AppRouterTable" positionX="-63" positionY="-18" width="128" height="75"/>
+        <element name="AppRouterRecord" positionX="-54" positionY="-9" width="128" height="90"/>
+    </elements>
+</model>


### PR DESCRIPTION
为 App Router 增加了本地缓存。

以外，还实现了一个基于 Core Data 的持久层。选择 Core Data 的原因主要有：

1. Core Data 是 Apple 官方提供的存储方案；
2. Core Data 可以更轻松地管理对象图；
3. Core Data 提供了自动的轻量迁移。

存储性能还没有具体测试，不过从 Ray 的实际表现来看，还没有出现明显的性能瓶颈。

@zapcannon87 