### PR TITLE
Fix confliction between dynamic lookup and built in property.

### DIFF
--- a/LeanCloud.podspec
+++ b/LeanCloud.podspec
@@ -6,6 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://leancloud.cn/'
   s.authors      = 'LeanCloud'
   s.source       = { :git => 'https://github.com/leancloud/swift-sdk.git', :tag => s.version }
+  s.swift_version = '4.2'
 
   s.ios.deployment_target     = '10.0'
   s.osx.deployment_target     = '10.12'

--- a/Sources/Storage/DataType/Object.swift
+++ b/Sources/Storage/DataType/Object.swift
@@ -152,8 +152,8 @@ open class LCObject: NSObject, LCValue, LCValueExtension, Sequence {
     func formattedJSONString(indentLevel: Int, numberOfSpacesForOneIndentLevel: Int = 4) -> String {
         let dictionary = LCDictionary(self.dictionary)
 
-        dictionary.__type = "Object"
-        dictionary.className = actualClassName
+        dictionary["__type"] = "Object".lcString
+        dictionary["className"] = actualClassName.lcString
 
         return dictionary.formattedJSONString(indentLevel: indentLevel, numberOfSpacesForOneIndentLevel: numberOfSpacesForOneIndentLevel)
     }


### PR DESCRIPTION
当使用 dot 语法访问成员时，Swift 会优先访问内置属性。

在 macOS 中，NSObject 刚好有一个名为 className 的内置属性，所以改用 subscript 来访问。

https://developer.apple.com/documentation/objectivec/nsobject/1411337-classname