### PR TITLE
Update Connection

### DIFF
--- a/LeanCloud.xcodeproj/project.pbxproj
+++ b/LeanCloud.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		D324CD9221774A9B003FA35F /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D324CD9121774A9B003FA35F /* Connection.swift */; };
 		D3301279217727870007286A /* Command.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3301278217727870007286A /* Command.pb.swift */; };
 		D3AA135B216E0D3A008FECA6 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AA1352216E0D3A008FECA6 /* WebSocket.swift */; };
+		D3DAD03C218DA402008BCD37 /* ConnectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DAD03B218DA402008BCD37 /* ConnectionTestCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -259,6 +260,7 @@
 		D3301278217727870007286A /* Command.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.pb.swift; sourceTree = "<group>"; };
 		D387262A217726B500DD8FBF /* SwiftProtobuf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftProtobuf.xcodeproj; path = SwiftProtobuf/SwiftProtobuf.xcodeproj; sourceTree = "<group>"; };
 		D3AA1352216E0D3A008FECA6 /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
+		D3DAD03B218DA402008BCD37 /* ConnectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionTestCase.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -367,6 +369,7 @@
 				834EA7141D2A139A00108DDC /* UserTestCase.swift */,
 				114E1E842153A3ED00DA7DB0 /* FileTestCase.swift */,
 				118763AE2176EA3A0078645B /* InstallationTestCase.swift */,
+				D3DAD03B218DA402008BCD37 /* ConnectionTestCase.swift */,
 				8342FCCC1C7B13A700C3CF15 /* Info.plist */,
 			);
 			path = LeanCloudTests;
@@ -770,6 +773,7 @@
 				116A682621427442004141A5 /* RouterTestCase.swift in Sources */,
 				118763AF2176EA3A0078645B /* InstallationTestCase.swift in Sources */,
 				8365CFA81D79849D006B856E /* TypeTestCase.swift in Sources */,
+				D3DAD03C218DA402008BCD37 /* ConnectionTestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LeanCloudTests/ConnectionTestCase.swift
+++ b/LeanCloudTests/ConnectionTestCase.swift
@@ -1,0 +1,299 @@
+//
+//  ConnectionTestCase.swift
+//  LeanCloudTests
+//
+//  Created by zapcannon87 on 2018/11/3.
+//  Copyright © 2018 LeanCloud. All rights reserved.
+//
+
+import XCTest
+@testable import LeanCloud
+
+class ConnectionTestCase: BaseTestCase {
+    
+    lazy var delegateQueueSpecificKey = DispatchSpecificKey<Int>()
+    lazy var delegateQueueSpecificValue = Int.random(in: 1...999)
+    lazy var delegateQueue = { () -> DispatchQueue in
+        let queue = DispatchQueue(label: "delegate.queue")
+        queue.setSpecific(key: delegateQueueSpecificKey, value: delegateQueueSpecificValue)
+        return queue
+    }()
+    
+    lazy var timerQueueSpecificKey = DispatchSpecificKey<Int>()
+    lazy var timerQueueSpecificValue = Int.random(in: 1...999)
+    lazy var timerQueue = { () -> DispatchQueue in
+        let queue = DispatchQueue(label: "timer.queue")
+        queue.setSpecific(key: timerQueueSpecificKey, value: timerQueueSpecificValue)
+        return queue
+    }()
+    
+    lazy var commandCallbackQueueSpecificKey = DispatchSpecificKey<Int>()
+    lazy var commandCallbackQueueSpecificValue = Int.random(in: 1...999)
+    lazy var commandCallbackQueue = { () -> DispatchQueue in
+        let queue = DispatchQueue(label: "command.callback.queue")
+        queue.setSpecific(key: commandCallbackQueueSpecificKey, value: commandCallbackQueueSpecificValue)
+        return queue
+    }()
+    
+    let timerTimeIntervalError: TimeInterval = 3
+    
+    func testTimerPingTimeout() {
+        
+        var endTestPingTimeout: Bool = false
+        let timer = Connection.Timer(timerQueue: timerQueue, commandCallbackQueue: commandCallbackQueue, pingTimeout: 5) { timer in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.timerQueueSpecificKey), self.timerQueueSpecificValue)
+            if timer.lastPingSentTimestamp != 0 {
+                let timeout: TimeInterval = Date().timeIntervalSince1970 - timer.lastPingSentTimestamp
+                print(timeout)
+                XCTAssertTrue(timeout < timer.pingTimeout + self.timerTimeIntervalError)
+                XCTAssertTrue(timeout > timer.pingTimeout - self.timerTimeIntervalError)
+                endTestPingTimeout = true
+            }
+        }
+        self.busywait(interval: 1) { () -> Bool in
+            return endTestPingTimeout
+        }
+        
+        timer.cancel()
+    }
+    
+    func testTimerPingpongInterval() {
+        
+        var endTestPingPong: Bool = false
+        let timer = Connection.Timer(timerQueue: timerQueue, commandCallbackQueue: commandCallbackQueue, pingpongInterval: 5) { timer in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.timerQueueSpecificKey), self.timerQueueSpecificValue)
+            self.timerQueue.async {
+                timer.lastPongReceivedTimestamp = Date().timeIntervalSince1970
+            }
+            if timer.lastPongReceivedTimestamp != 0 {
+                let pingpongInterval: TimeInterval = Date().timeIntervalSince1970 - timer.lastPongReceivedTimestamp
+                print(pingpongInterval)
+                XCTAssertTrue(pingpongInterval < timer.pingpongInterval + self.timerTimeIntervalError)
+                XCTAssertTrue(pingpongInterval > timer.pingpongInterval - self.timerTimeIntervalError)
+                endTestPingPong = true
+            }
+        }
+        self.busywait(interval: 1) { () -> Bool in
+            return endTestPingPong
+        }
+        
+        timer.cancel()
+    }
+    
+    func testTimerCheckCommandCallback() {
+        
+        var endTestCommandTimeout: Int = 0
+        let timer = Connection.Timer(timerQueue: timerQueue, commandCallbackQueue: commandCallbackQueue) { _ in }
+        timerQueue.async {
+            let commandCallbackInsertTimestamp: TimeInterval = Date().timeIntervalSince1970
+            // test callback timeout 1
+            let index1: UInt16 = 1
+            let commandTTL1: TimeInterval = 5
+            timer.insert(commandCallback: Connection.CommandCallback(closure: { (result) in
+                XCTAssertEqual(DispatchQueue.getSpecific(key: self.commandCallbackQueueSpecificKey), self.commandCallbackQueueSpecificValue)
+                switch result {
+                case .error(_):
+                    let interval: TimeInterval = Date().timeIntervalSince1970 - commandCallbackInsertTimestamp
+                    print(interval)
+                    XCTAssertTrue(interval < commandTTL1 + self.timerTimeIntervalError)
+                    XCTAssertTrue(interval > commandTTL1 - self.timerTimeIntervalError)
+                case .inCommand(_):
+                    XCTFail()
+                }
+                self.timerQueue.async {
+                    XCTAssertEqual(timer.commandIndexSequence.contains(index1), false)
+                    XCTAssertNil(timer.commandCallbackCollection[index1])
+                    endTestCommandTimeout += 1
+                }
+            }, timeToLive: commandTTL1), index: index1)
+            // test callback timeout 2
+            let index2: UInt16 = 2
+            let commandTTL2: TimeInterval = 10
+            timer.insert(commandCallback: Connection.CommandCallback(closure: { (result) in
+                XCTAssertEqual(DispatchQueue.getSpecific(key: self.commandCallbackQueueSpecificKey), self.commandCallbackQueueSpecificValue)
+                switch result {
+                case .error(_):
+                    let interval: TimeInterval = Date().timeIntervalSince1970 - commandCallbackInsertTimestamp
+                    print(interval)
+                    XCTAssertTrue(interval < commandTTL2 + self.timerTimeIntervalError)
+                    XCTAssertTrue(interval > commandTTL2 - self.timerTimeIntervalError)
+                case .inCommand(_):
+                    XCTFail()
+                }
+                self.timerQueue.async {
+                    XCTAssertEqual(timer.commandIndexSequence.contains(index2), false)
+                    XCTAssertNil(timer.commandCallbackCollection[index2])
+                    endTestCommandTimeout += 1
+                }
+            }, timeToLive: commandTTL2), index: index2)
+            // test callback succeeded
+            let index3: UInt16 = 3
+            timer.insert(commandCallback: Connection.CommandCallback(closure: { (result) in
+                XCTAssertEqual(DispatchQueue.getSpecific(key: self.commandCallbackQueueSpecificKey), self.commandCallbackQueueSpecificValue)
+                switch result {
+                case .error(_):
+                    XCTFail()
+                case .inCommand(let command):
+                    XCTAssertTrue(command.i == index3)
+                }
+                self.timerQueue.async {
+                    XCTAssertEqual(timer.commandIndexSequence.contains(index3), false)
+                    XCTAssertNil(timer.commandCallbackCollection[index3])
+                    endTestCommandTimeout += 1
+                }
+            }, timeToLive: 30), index: index3)
+            timer.handle(callbackCommand: {
+                var command = IMGenericCommand()
+                command.i = Int32(index3)
+                return command
+            }())
+        }
+        self.busywait(interval: 1) { () -> Bool in
+            return endTestCommandTimeout == 3
+        }
+        
+        timer.cancel()
+    }
+    
+    func testTimerCancel() {
+        
+        var endTestCancelTimer: Bool = false
+        let timer = Connection.Timer(timerQueue: timerQueue, commandCallbackQueue: commandCallbackQueue) { _ in }
+        timerQueue.async {
+            timer.insert(commandCallback: Connection.CommandCallback(closure: { (result) in
+                XCTAssertEqual(DispatchQueue.getSpecific(key: self.commandCallbackQueueSpecificKey), self.commandCallbackQueueSpecificValue)
+                switch result {
+                case .error(_):
+                    break
+                case .inCommand(_):
+                    XCTFail()
+                }
+                endTestCancelTimer = true
+            }, timeToLive: 30), index: 1)
+            timer.cancel()
+        }
+        self.busywait(interval: 1) { () -> Bool in
+            return endTestCancelTimer
+        }
+    }
+    
+    func testConnection() {
+        
+        let application = LCApplication.default
+        let clientId1 = String(#function[..<#function.index(of: "(")!]) + "1"
+        let clientId2 = String(#function[..<#function.index(of: "(")!]) + "2"
+        
+        var endTestConnect: Int = 0
+        let delegator = ConnectionDelegator()
+        let connection = Connection(application: application, delegate: delegator, lcimProtocol: .protobuf1, customRTMServer: "wss://rtm51.leancloud.cn", delegateQueue: delegateQueue)
+        delegator.connectionInConnectingClosure = { (connection) in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.delegateQueueSpecificKey), self.delegateQueueSpecificValue)
+            endTestConnect += 1
+        }
+        delegator.connectionDidConnectClosure = { (connection) in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.delegateQueueSpecificKey), self.delegateQueueSpecificValue)
+            endTestConnect += 1
+        }
+        connection.connect()
+        self.busywait() { () -> Bool in
+            return endTestConnect == 2
+        }
+        
+        var endTestSendCommand: Bool = false
+        connection.send(command: {
+            var sessionCommand = IMSessionCommand()
+            sessionCommand.deviceToken = UUID().uuidString
+            sessionCommand.ua = "swift-sdk/\(LeanCloud.version)"
+            var command = IMGenericCommand()
+            command.cmd = .session
+            command.op = .open
+            command.appID = application.id
+            command.peerID = clientId1
+            command.sessionMessage = sessionCommand
+            print(command.debugDescription)
+            return command
+        }()) { (result) in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.delegateQueueSpecificKey), self.delegateQueueSpecificValue)
+            switch result {
+            case .inCommand(let command):
+                print(command.debugDescription)
+                XCTAssertTrue(command.hasSessionMessage)
+                XCTAssertTrue(command.sessionMessage.hasSt)
+                XCTAssertTrue(command.sessionMessage.hasStTtl)
+            case .error(_):
+                XCTFail()
+            }
+            endTestSendCommand = true
+        }
+        self.busywait() { () -> Bool in
+            return endTestSendCommand
+        }
+        
+        var endTestCreateConversation: Int = 0
+        delegator.connectionDidReceiveCommandClosure = { (connection, command) in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.delegateQueueSpecificKey), self.delegateQueueSpecificValue)
+            if command.cmd == .conv {
+                if command.op == .joined || command.op == .membersJoined {
+                    print(command.debugDescription)
+                    endTestCreateConversation += 1
+                }
+            }
+        }
+        connection.send(command: {
+            var convCommand = IMConvCommand()
+            convCommand.m = [clientId1, clientId2]
+            var command = IMGenericCommand()
+            command.cmd = .conv
+            command.op = .start
+            command.convMessage = convCommand
+            print(command.debugDescription)
+            return command
+        }()) { (result) in
+            XCTAssertEqual(DispatchQueue.getSpecific(key: self.delegateQueueSpecificKey), self.delegateQueueSpecificValue)
+            switch result {
+            case .inCommand(let command):
+                print(command.debugDescription)
+                XCTAssertTrue(command.hasConvMessage)
+                XCTAssertTrue(command.convMessage.hasCid)
+            case .error(_):
+                XCTFail()
+            }
+            endTestCreateConversation += 1
+        }
+        self.busywait() { () -> Bool in
+            return endTestCreateConversation == 3
+        }
+        
+        connection.disconnect()
+    }
+
+}
+
+class ConnectionDelegator: ConnectionDelegate {
+    
+    var connectionInConnectingClosure: ((Connection) -> Void)?
+    func connectionInConnecting(connection: Connection) {
+        connectionInConnectingClosure?(connection)
+    }
+    
+    var connectionDidConnectClosure: ((Connection) -> Void)?
+    func connectionDidConnect(connection: Connection) {
+        connectionDidConnectClosure?(connection)
+    }
+    
+    var connectionDidFailInConnectingClosure: ((Connection, Connection.Event) -> Void)?
+    func connection(connection: Connection, didFailInConnecting event: Connection.Event) {
+        connectionDidFailInConnectingClosure?(connection, event)
+    }
+    
+    var connectionDidDisconnectClosure: ((Connection, Connection.Event) -> Void)?
+    func connection(connection: Connection, didDisconnect event: Connection.Event) {
+        connectionDidDisconnectClosure?(connection, event)
+    }
+    
+    var connectionDidReceiveCommandClosure: ((Connection, IMGenericCommand) -> Void)?
+    func connection(connection: Connection, didReceiveCommand inCommand: IMGenericCommand) {
+        connectionDidReceiveCommandClosure?(connection, inCommand)
+    }
+    
+}

--- a/Sources/IM/Connection.swift
+++ b/Sources/IM/Connection.swift
@@ -47,14 +47,12 @@ class Connection {
     
     /// Event for ConnectionDelegate
     ///
-    /// - dealloc: The connected or in-connecting Connection-Instance was releaseed.
     /// - disconnectInvoked: The connected or in-connecting Connection-Instance was invoked disconnect().
     /// - appInBackground: The connected or in-connecting Connection-Instance was disconencted due to APP enter background, or Connection-Instance can't start connecting.
     /// - networkNotReachable: The connected or in-connecting Connection-Instance was disconencted due to network not reachable, or Connection-Instance can't start connecting.
     /// - networkChanged: The connected or in-connecting Connection-Instance was disconencted due to network's primary interface changed.
     /// - error: maybe LeanCloud error, websocket error or other network error.
     enum Event {
-        case dealloc
         case disconnectInvoked
         case appInBackground
         case networkNotReachable
@@ -292,7 +290,8 @@ class Connection {
         #if !os(watchOS)
         self.reachabilityManager?.stopListening()
         #endif
-        self.tryClearConnection(with: .dealloc)
+        self.socket?.disconnect()
+        self.timer?.cancel()
     }
     
     /// Try connecting RTM server, if websocket exists and auto reconnection is enabled, then this action will be ignored.


### PR DESCRIPTION
* 更新了 Connection 的接口以及文档
* 增加了 Connection 的测试用例
    * 建立连接，收发消息，Connection 内置的 Timer 的测试用例都 OK 了
    * App 前后台状态，网络状态以及重连暂无测试用例，还需要再研究研究
    * 还没有 RTM Router，所以目前只能通过设置 custom RTM server 来建立连接
* 还需补充 logger 和详细的 error 回调

目前基本已经可用，后面再做一些小调整估计就差不多了 @tang3w 