### PR TITLE
 Update Reconnection Strategy for Server Error

### DIFF
--- a/Sources/IM/Connection.swift
+++ b/Sources/IM/Connection.swift
@@ -200,6 +200,7 @@ class Connection {
     private var timer: Timer? = nil
     private var isAutoReconnectionEnabled: Bool = false
     private var useSecondaryServer: Bool = false
+    private var afterWorkItemForReconnection: DispatchWorkItem? = nil
     private var serialIndex: UInt16 = 1
     private var nextSerialIndex: UInt16 {
         let index: UInt16 = self.serialIndex
@@ -302,6 +303,7 @@ class Connection {
         #endif
         self.socket?.disconnect()
         self.timer?.cancel()
+        self.afterWorkItemForReconnection?.cancel()
     }
     
     /// Try connecting RTM server, if websocket exists and auto reconnection is enabled, then this action will be ignored.
@@ -436,8 +438,30 @@ extension Connection {
         return nil
     }
     
+    private func check(isServerError error: Error?) -> Bool {
+        if error == nil {
+            // Result: Stream end encountered, Socket Connection reset by remote peer.
+            // Reason: Maybe due to Network Environment, maybe due to LeanCloud Server Error.
+            // Handling: Anyway, SDK regrad it as LeanCloud Server Error.
+            return true
+        } else if let wsError: WSError = error as? WSError {
+            switch wsError.type {
+            case .protocolError, .invalidSSLError, .upgradeError:
+                // 99.99% is LeanCloud Server Error.
+                return true
+            default:
+                break
+            }
+        }
+        return false
+    }
+    
     private func tryConnecting() {
         assert(self.specificAssertion)
+        if let workItem: DispatchWorkItem = self.afterWorkItemForReconnection {
+            workItem.cancel()
+            self.afterWorkItemForReconnection = nil
+        }
         self.getRTMServer { (result: LCGenericResult<URL>) in
             assert(self.specificAssertion)
             guard self.socket == nil else {
@@ -476,6 +500,10 @@ extension Connection {
     
     private func tryClearConnection(with event: Event) {
         assert(self.specificAssertion)
+        if let workItem: DispatchWorkItem = self.afterWorkItemForReconnection {
+            workItem.cancel()
+            self.afterWorkItemForReconnection = nil
+        }
         if let socket: WebSocket = self.socket {
             socket.delegate = nil
             socket.pongDelegate = nil
@@ -515,6 +543,36 @@ extension Connection {
         }
     }
     
+    private func handleDisconnectForServerError() {
+        assert(self.specificAssertion)
+        let secondaryServerEncounteredError: Bool = self.useSecondaryServer
+        self.useSecondaryServer.toggle()
+        if secondaryServerEncounteredError {
+            // Primary & Secondary Server both encountered error
+            do {
+                let routerCache: RTMRouterCache = self.rtmRouter.cache
+                if let routingTable = try routerCache.getRoutingTable(),
+                    Date().timeIntervalSince1970 - routingTable.createdAt.timeIntervalSince1970 > 60
+                {
+                    try routerCache.clear()
+                }
+            } catch {
+                Logger.shared.error(error)
+            }
+            if self.isAutoReconnectionEnabled {
+                let workItem = DispatchWorkItem() { [weak self] in
+                    self?.afterWorkItemForReconnection = nil
+                    self?.tryConnecting()
+                }
+                self.afterWorkItemForReconnection = workItem
+                self.serialQueue.asyncAfter(deadline: .now() + 10, execute: workItem)
+            }
+        } else {
+            // Primary Server encountered error
+            self.tryConnecting()
+        }
+    }
+    
 }
 
 // MARK: - WebSocketDelegate
@@ -539,32 +597,31 @@ extension Connection: WebSocketDelegate, WebSocketPongDelegate {
         assert(self.specificAssertion)
         assert(self.socket === socket)
         Logger.shared.verbose("\(socket) disconnect with error: \(String(describing: error))")
+        let isServerError: Bool = self.check(isServerError: error)
         let disconnectError: Error = error ?? LCError(code: .connectionLost)
-        if let wsError: WSError = disconnectError as? WSError {
-            if wsError.type == .protocolError {
-                // unexpectation error or close by server.
-                self.tryClearConnection(with: .error(disconnectError))
-                return
-            } else if wsError.type == .invalidSSLError || wsError.type == .upgradeError {
-                // SSL or HTTP upgrade failed, maybe should use another server.
-                self.useSecondaryServer.toggle()
-            }
-        }
         if self.timer != nil {
             // timer exists means the connected socket was disconnected.
             self.tryClearConnection(with: .error(disconnectError))
         } else {
             // timer not exists means connecting failed.
-            self.delegateQueue.async {
-                self.delegate?.connection(connection: self, didFailInConnecting: .error(disconnectError))
-            }
             self.socket?.delegate = nil
             self.socket?.pongDelegate = nil
             self.socket = nil
+            if isServerError && !self.useSecondaryServer {
+                // Primary Server Error in connecting
+                // Should try Secondary Server and no need to notify delegator.
+            } else {
+                self.delegateQueue.async {
+                    self.delegate?.connection(connection: self, didFailInConnecting: .error(disconnectError))
+                }
+            }
         }
-        if self.isAutoReconnectionEnabled {
-            // all condition but 'error or closing of WebSocket-Protocol', should try reconnecting.
-            self.tryConnecting()
+        if isServerError {
+            self.handleDisconnectForServerError()
+        } else {
+            if self.isAutoReconnectionEnabled {
+                self.tryConnecting()
+            }
         }
     }
     

--- a/Sources/IM/RTMRouter.swift
+++ b/Sources/IM/RTMRouter.swift
@@ -22,6 +22,9 @@ struct RTMRoutingTable {
     /// Expiration date, it's a local date.
     let expiration: Date
 
+    /// Creation date, it's a local date.
+    let createdAt: Date
+    
 }
 
 /**
@@ -79,7 +82,7 @@ final class RTMRouter {
 
         let expirationDate = Date(timeIntervalSinceNow: ttl)
 
-        let routingTable = RTMRoutingTable(primary: primaryURL, secondary: secondaryURL, expiration: expirationDate)
+        let routingTable = RTMRoutingTable(primary: primaryURL, secondary: secondaryURL, expiration: expirationDate, createdAt: Date())
 
         return .success(value: routingTable)
     }

--- a/Sources/IM/RTMRouterCache.swift
+++ b/Sources/IM/RTMRouterCache.swift
@@ -32,6 +32,7 @@ final class RTMRouterCache: LocalStorage, LocalStorageProtocol {
                 let primaryURLString = entity.primary,
                 let primaryURL = URL(string: primaryURLString),
                 let expiration = entity.expiration,
+                let createdAt = entity.createdAt,
                 Date() < expiration
             else {
                 try deleteAllObjects(type: RTMRoutingTableEntity.self)
@@ -45,7 +46,7 @@ final class RTMRouterCache: LocalStorage, LocalStorageProtocol {
                 secondaryURL = URL(string: secondaryURLString)
             }
 
-            let routingTable = RTMRoutingTable(primary: primaryURL, secondary: secondaryURL, expiration: expiration)
+            let routingTable = RTMRoutingTable(primary: primaryURL, secondary: secondaryURL, expiration: expiration, createdAt: createdAt)
 
             return routingTable
         }
@@ -62,6 +63,7 @@ final class RTMRouterCache: LocalStorage, LocalStorageProtocol {
                 entity.primary = routingTable.primary.absoluteString
                 entity.secondary = routingTable.secondary?.absoluteString
                 entity.expiration = routingTable.expiration
+                entity.createdAt = routingTable.createdAt
             }
 
             try save()

--- a/Sources/IM/RTMRouterCache.xcdatamodeld/RTMRouterCache.xcdatamodel/contents
+++ b/Sources/IM/RTMRouterCache.xcdatamodeld/RTMRouterCache.xcdatamodel/contents
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18A391" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="RTMRoutingTableEntity" representedClassName="RTMRoutingTableEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="expiration" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="primary" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="secondary" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
-        <element name="RTMRoutingTableEntity" positionX="-54" positionY="-9" width="128" height="90"/>
+        <element name="RTMRoutingTableEntity" positionX="-54" positionY="-9" width="128" height="105"/>
     </elements>
 </model>


### PR DESCRIPTION
* RTM Router 缓存增加了「创建时间」属性
* Connection 针对服务器错误做了以下更改
    * 无论自动重连打开与否，由于服务器错误导致的 Primary Server 连接失败或断开，立即尝试连接 Secondary Server
    * 由于服务器错误导致的 Secondary Server 连接失败或断开，如果当前时间已超过 RTM Router 缓存的创建时间 60 秒，清理 RTM Router 缓存。如果自动重连处于开启状态，在 10 秒后尝试重连。
    * TCP reset 导致的断开视作服务器错误。

这个改动主要是为了解决「在 RTM Router 缓存没有过期，RTM Router 缓存的 Server 都因为服务器错误连接不上，而 RTM Router 已经切换到可用的 Server 时」，SDK 能够在较短的时间内自动清理无效缓存并能够不间断的尝试重连服务器。

上述的「60 秒」和「10 秒」是在和后端讨论后决定的。在 Runtime 环境测试过了，应该没问题。

@tang3w 