### PR TITLE
Update LCClient & Connection

### DIFF
--- a/LeanCloud.xcodeproj/project.pbxproj
+++ b/LeanCloud.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		D324CD9221774A9B003FA35F /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D324CD9121774A9B003FA35F /* Connection.swift */; };
 		D3301279217727870007286A /* Command.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3301278217727870007286A /* Command.pb.swift */; };
 		D3AA135B216E0D3A008FECA6 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AA1352216E0D3A008FECA6 /* WebSocket.swift */; };
+		D3AC7BA821AE9C1A00C6C557 /* ClientTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AC7BA721AE9C1A00C6C557 /* ClientTestCase.swift */; };
 		D3DAD03C218DA402008BCD37 /* ConnectionTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DAD03B218DA402008BCD37 /* ConnectionTestCase.swift */; };
 		D3E1F48D2193EDF3007B6FFB /* ConnectionTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E1F48C2193EDF3007B6FFB /* ConnectionTestViewController.swift */; };
 		D3E1F4AE21940E8E007B6FFB /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3872641217726B500DD8FBF /* SwiftProtobuf.framework */; };
@@ -327,6 +328,7 @@
 		D3301278217727870007286A /* Command.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.pb.swift; sourceTree = "<group>"; };
 		D387262A217726B500DD8FBF /* SwiftProtobuf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftProtobuf.xcodeproj; path = SwiftProtobuf/SwiftProtobuf.xcodeproj; sourceTree = "<group>"; };
 		D3AA1352216E0D3A008FECA6 /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
+		D3AC7BA721AE9C1A00C6C557 /* ClientTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientTestCase.swift; sourceTree = "<group>"; };
 		D3DAD03B218DA402008BCD37 /* ConnectionTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionTestCase.swift; sourceTree = "<group>"; };
 		D3E1F48C2193EDF3007B6FFB /* ConnectionTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionTestViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -444,6 +446,7 @@
 			isa = PBXGroup;
 			children = (
 				11FBD1E6215BEEB400370C61 /* Resources */,
+				8342FCCC1C7B13A700C3CF15 /* Info.plist */,
 				83D5923D1CD88846007177C5 /* BridgingHeader.h */,
 				8342FCCA1C7B13A700C3CF15 /* BaseTestCase.swift */,
 				11FBD1E4215BDDCA00370C61 /* CoreTestCase.swift */,
@@ -460,7 +463,7 @@
 				118763AE2176EA3A0078645B /* InstallationTestCase.swift */,
 				D3DAD03B218DA402008BCD37 /* ConnectionTestCase.swift */,
 				1123922B2191669100ECCBCC /* RTMTestCase.swift */,
-				8342FCCC1C7B13A700C3CF15 /* Info.plist */,
+				D3AC7BA721AE9C1A00C6C557 /* ClientTestCase.swift */,
 			);
 			path = LeanCloudTests;
 			sourceTree = "<group>";
@@ -929,6 +932,7 @@
 				83BC11D61CDD76E900D7E7A6 /* ACLTestCase.swift in Sources */,
 				1178D10F213F7B9600429131 /* APITestCase.swift in Sources */,
 				8334561C1CE589E500D42725 /* EngineTestCase.swift in Sources */,
+				D3AC7BA821AE9C1A00C6C557 /* ClientTestCase.swift in Sources */,
 				116A682621427442004141A5 /* RouterTestCase.swift in Sources */,
 				1123922C2191669100ECCBCC /* RTMTestCase.swift in Sources */,
 				118763AF2176EA3A0078645B /* InstallationTestCase.swift in Sources */,

--- a/LeanCloud.xcodeproj/xcshareddata/xcschemes/LeanCloudTests.xcscheme
+++ b/LeanCloud.xcodeproj/xcshareddata/xcschemes/LeanCloudTests.xcscheme
@@ -41,6 +41,11 @@
          </TestableReference>
       </Testables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
@@ -63,6 +68,11 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/LeanCloudTests/ClientTestCase.swift
+++ b/LeanCloudTests/ClientTestCase.swift
@@ -90,13 +90,13 @@ class ClientTestCase: BaseTestCase {
         exp3.expectedFulfillmentCount = 2
         exp3.assertForOverFulfill = true
         
-        client1.open(action: .resume) { (result) in
+        client1.open(options: []) { (result) in
             
             XCTAssertEqual(result.error?.code, 4111)
             exp3.fulfill()
             
             application1.currentInstallation.set(deviceToken: deviceToken2, apnsTeamId: "")
-            client1.open(action: .resume) { (result) in
+            client1.open(options: []) { (result) in
                 
                 XCTAssertNil(result.error)
                 exp3.fulfill()

--- a/LeanCloudTests/ClientTestCase.swift
+++ b/LeanCloudTests/ClientTestCase.swift
@@ -1,0 +1,165 @@
+//
+//  ClientTestCase.swift
+//  LeanCloudTests
+//
+//  Created by zapcannon87 on 2018/11/28.
+//  Copyright © 2018 LeanCloud. All rights reserved.
+//
+
+import XCTest
+@testable import LeanCloud
+
+class ClientTestCase: BaseTestCase {
+
+    func testClientOpenClose() {
+        
+        let client = try! LCClient(id: String(#function[..<#function.index(of: "(")!]))
+        
+        for _ in 0..<3 {
+            
+            let exp = self.expectation(description: "client open success")
+            exp.expectedFulfillmentCount = 2
+            exp.assertForOverFulfill = true
+            
+            client.open { (result) in
+                
+                XCTAssertTrue(Thread.isMainThread)
+                XCTAssertNil(result.error)
+                exp.fulfill()
+                
+                client.close() { (result) in
+                
+                    XCTAssertTrue(Thread.isMainThread)
+                    XCTAssertNil(result.error)
+                    exp.fulfill()
+                }
+            }
+            
+            self.waitForExpectations(timeout: 600)
+        }
+    }
+    
+    func testClientSessionConflict() {
+        
+        let id = String(#function[..<#function.index(of: "(")!])
+        let tag = "tag"
+        
+        let application1 = LCApplication(id: LCApplication.default.id, key: LCApplication.default.key)
+        let deviceToken1 = UUID().uuidString
+        application1.currentInstallation.set(deviceToken: deviceToken1, apnsTeamId: "")
+        let delegator1 = ClientDelegator()
+        let client1 = try! LCClient(id: id, tag: tag, delegate: delegator1, application: application1)
+        
+        let application2 = LCApplication(id: LCApplication.default.id, key: LCApplication.default.key)
+        let deviceToken2 = UUID().uuidString
+        application2.currentInstallation.set(deviceToken: deviceToken2, apnsTeamId: "")
+        let delegator2 = ClientDelegator()
+        let client2 = try! LCClient(id: id, tag: tag, delegate: delegator2, application: application2)
+        
+        let exp1 = self.expectation(description: "client1 open success")
+        
+        client1.open { (result) in
+            
+            XCTAssertNil(result.error)
+            exp1.fulfill()
+        }
+        
+        self.wait(for: [exp1], timeout: 600)
+        
+        let exp2 = self.expectation(description: "client2 open success & kick client1 success")
+        exp2.expectedFulfillmentCount = 2
+        exp2.assertForOverFulfill = true
+        
+        delegator1.didCloseSession = { (client, error) in
+            
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertTrue(client === client1)
+            XCTAssertEqual(error.code, 4111)
+            exp2.fulfill()
+        }
+        
+        client2.open { (result) in
+            
+            XCTAssertNil(result.error)
+            exp2.fulfill()
+        }
+        
+        self.wait(for: [exp2], timeout: 600)
+        
+        let exp3 = self.expectation(description: "client1 resume with deviceToken1 fail, and set deviceToken2 then resume success")
+        exp3.expectedFulfillmentCount = 2
+        exp3.assertForOverFulfill = true
+        
+        client1.open(action: .resume) { (result) in
+            
+            XCTAssertEqual(result.error?.code, 4111)
+            exp3.fulfill()
+            
+            application1.currentInstallation.set(deviceToken: deviceToken2, apnsTeamId: "")
+            client1.open(action: .resume) { (result) in
+                
+                XCTAssertNil(result.error)
+                exp3.fulfill()
+            }
+        }
+        
+        self.wait(for: [exp3], timeout: 600)
+    }
+    
+    func testClientReportDeviceToken() {
+        
+        let client = try! LCClient(id: String(#function[..<#function.index(of: "(")!]))
+        
+        let exp = self.expectation(description: "client report device token success")
+        exp.expectedFulfillmentCount = 2
+        exp.assertForOverFulfill = true
+        
+        client.open { (result) in
+            
+            XCTAssertNil(result.error)
+            exp.fulfill()
+            
+            client.installation.set(deviceToken: UUID().uuidString, apnsTeamId: "")
+        }
+        
+        let _ = NotificationCenter.default.addObserver(forName: LCClient.TestReportDeviceTokenNotification, object: client, queue: OperationQueue.main) { (notification) in
+            
+            let result = notification.userInfo?["result"] as! Connection.CommandCallback.Result
+            switch result {
+            case .error(let error):
+                XCTFail("\(error)")
+            case .inCommand(let command):
+                XCTAssertEqual(command.cmd, .report)
+                XCTAssertEqual(command.op, .uploaded)
+            }
+            exp.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 600)
+    }
+
+}
+
+class ClientDelegator: NSObject, LCClientDelegate {
+    
+    var didOpenSession: ((LCClient) -> Void)?
+    func client(didOpenSession client: LCClient) {
+        self.didOpenSession?(client)
+    }
+    
+    var didBecomeResumeSession: ((LCClient) -> Void)?
+    func client(didBecomeResumeSession client: LCClient) {
+        self.didBecomeResumeSession?(client)
+    }
+    
+    var didPauseSession: ((LCClient, LCError) -> Void)?
+    func client(_ client: LCClient, didPauseSession error: LCError) {
+        self.didPauseSession?(client, error)
+    }
+    
+    var didCloseSession: ((LCClient, LCError) -> Void)?
+    func client(_ client: LCClient, didCloseSession error: LCError) {
+        self.didCloseSession?(client, error)
+    }
+    
+}

--- a/LeanCloudTests/ClientTestCase.swift
+++ b/LeanCloudTests/ClientTestCase.swift
@@ -125,13 +125,8 @@ class ClientTestCase: BaseTestCase {
         let _ = NotificationCenter.default.addObserver(forName: LCClient.TestReportDeviceTokenNotification, object: client, queue: OperationQueue.main) { (notification) in
             
             let result = notification.userInfo?["result"] as! Connection.CommandCallback.Result
-            switch result {
-            case .error(let error):
-                XCTFail("\(error)")
-            case .inCommand(let command):
-                XCTAssertEqual(command.cmd, .report)
-                XCTAssertEqual(command.op, .uploaded)
-            }
+            XCTAssertEqual(result.command?.cmd, .report)
+            XCTAssertEqual(result.command?.op, .uploaded)
             exp.fulfill()
         }
         

--- a/RuntimeTests-iOS/Base.lproj/Main.storyboard
+++ b/RuntimeTests-iOS/Base.lproj/Main.storyboard
@@ -71,9 +71,32 @@
                     <view key="view" contentMode="scaleToFill" id="VMO-Rp-q9Z">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="34g-0Z-kfD">
+                                <rect key="frame" x="169" y="325" width="37" height="37"/>
+                                <color key="color" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </activityIndicatorView>
+                            <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FMD-R6-Tea">
+                                <rect key="frame" x="0.0" y="333.5" width="375" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="FMD-R6-Tea" firstAttribute="centerX" secondItem="UKA-7b-7J7" secondAttribute="centerX" id="I71-GX-ad1"/>
+                            <constraint firstItem="34g-0Z-kfD" firstAttribute="centerY" secondItem="UKA-7b-7J7" secondAttribute="centerY" id="UiG-Zj-t7x"/>
+                            <constraint firstItem="FMD-R6-Tea" firstAttribute="centerY" secondItem="UKA-7b-7J7" secondAttribute="centerY" id="mro-Xh-ZTT"/>
+                            <constraint firstItem="34g-0Z-kfD" firstAttribute="centerX" secondItem="UKA-7b-7J7" secondAttribute="centerX" id="tlB-YM-VZ9"/>
+                            <constraint firstItem="FMD-R6-Tea" firstAttribute="width" secondItem="VMO-Rp-q9Z" secondAttribute="width" id="zuC-ry-5kI"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="UKA-7b-7J7"/>
                     </view>
+                    <connections>
+                        <outlet property="activityIndicator" destination="34g-0Z-kfD" id="hTb-dK-u80"/>
+                        <outlet property="label" destination="FMD-R6-Tea" id="4d9-NY-ZG6"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="h1b-N7-Hzv" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/RuntimeTests-iOS/ConnectionTestViewController.swift
+++ b/RuntimeTests-iOS/ConnectionTestViewController.swift
@@ -12,38 +12,59 @@ import UIKit
 
 class ConnectionTestViewController: UIViewController {
     
-    var connection: Connection!
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet weak var label: UILabel!
+    var client: LCClient!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        connection = Connection(application: LCApplication.default, delegate: self, lcimProtocol: .protobuf1)
-        connection.setAutoReconnectionEnabled(with: true)
-        connection.connect()
+        self.client = try! LCClient(id: "ConnectionTestViewController", delegate: self)
+        self.client.open { (result) in
+            self.label.isHidden.toggle()
+            self.activityIndicator.stopAnimating()
+            switch result {
+            case .success:
+                self.showConnected()
+            case .failure(error: let error):
+                self.showError(error)
+            }
+        }
+    }
+    
+    func showError(_ error: Error) {
+        self.label.text = "\(error)"
+        self.label.textColor = .red
+    }
+    
+    func showConnecting() {
+        self.label.text = "Connecting ..."
+        self.label.textColor = .blue
+    }
+    
+    func showConnected() {
+        self.label.text = "Connected!"
+        self.label.textColor = .green
     }
     
 }
 
-extension ConnectionTestViewController: ConnectionDelegate {
+extension ConnectionTestViewController: LCClientDelegate {
     
-    func connectionInConnecting(connection: Connection) {
-        
+    func client(didOpenSession client: LCClient) {
+        self.showConnected()
     }
     
-    func connectionDidConnect(connection: Connection) {
-        
+    func client(didBecomeResumeSession client: LCClient) {
+        self.showConnecting()
     }
     
-    func connection(connection: Connection, didFailInConnecting event: Connection.Event) {
-        
+    func client(_ client: LCClient, didCloseSession error: LCError) {
+        self.showError(error)
     }
     
-    func connection(connection: Connection, didDisconnect event: Connection.Event) {
-        
-    }
-    
-    func connection(connection: Connection, didReceiveCommand inCommand: IMGenericCommand) {
-        
+    func client(_ client: LCClient, didPauseSession error: LCError) {
+        self.showError(error)
     }
     
 }

--- a/Sources/IM/Client.swift
+++ b/Sources/IM/Client.swift
@@ -358,7 +358,6 @@ private extension LCClient {
         outCommand.appID = self.application.id
         outCommand.peerID = self.id
         var sessionCommand = IMSessionCommand()
-        outCommand.sessionMessage = sessionCommand
         #if os(iOS) || os(tvOS)
         sessionCommand.deviceToken = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         #else
@@ -368,6 +367,7 @@ private extension LCClient {
         if let tag: String = self.tag {
             sessionCommand.tag = tag
         }
+        outCommand.sessionMessage = sessionCommand
         return outCommand
     }
     

--- a/Sources/IM/Client.swift
+++ b/Sources/IM/Client.swift
@@ -435,9 +435,9 @@ private extension LCClient {
         reportCommand.data = token
         outCommand.reportMessage = reportCommand
         self.connection.send(command: outCommand) { result in
-            if case let .inCommand(inCommand) = result {
-                if !(inCommand.cmd == .report && inCommand.op == .uploaded) {
-                    Logger.shared.error(inCommand)
+            if let command: IMGenericCommand = result.command {
+                if !(command.cmd == .report && command.op == .uploaded) {
+                    Logger.shared.error(command)
                 }
             }
             #if DEBUG

--- a/Sources/IM/Client.swift
+++ b/Sources/IM/Client.swift
@@ -7,35 +7,34 @@
 //
 
 import Foundation
+#if os(iOS) || os(tvOS)
+import UIKit
+#endif
 
 /**
  An LCClient represents an entity which can send and receive messages in IM system.
-
+ 
  Clients and messages are organized by conversation, that is, a client can only send and receive messages in context of conversation.
  */
 public final class LCClient: NSObject {
-
+    
     /**
      Options that can modify behaviors of client.
      */
     public struct Options: OptionSet {
-
+        
         public let rawValue: Int
-
+        
         public init(rawValue: Int) {
             self.rawValue = rawValue
         }
-
+        
         /// Default options.
         public static let `default`: Options = []
-
-        /// Manage session state manually.
-        /// Maybe we can public this property someday.
-        static let manageSessionStateManually = Options(rawValue: 1 << 0)
-
+        
         /// Receive unread message count after session did open.
-        public static let receiveUnreadMessageCountAfterSessionDidOpen = Options(rawValue: 1 << 1)
-
+        public static let receiveUnreadMessageCountAfterSessionDidOpen = Options(rawValue: 1 << 0)
+        
         /// Get IM protocol for current options.
         var lcimProtocol: Connection.LCIMProtocol {
             if contains(.receiveUnreadMessageCountAfterSessionDidOpen) {
@@ -44,131 +43,100 @@ public final class LCClient: NSObject {
                 return .protobuf1
             }
         }
-
-        /// Get if session should reconnect automatically.
-        var isAutoReconnectionEnabled: Bool {
-            if contains(.manageSessionStateManually) {
-                return false
-            } else {
-                return true
-            }
-        }
-
+        
     }
-
+    
     /**
      Client session state.
      */
     public enum SessionState {
-
+        
         /// Session is opened
         case opened
-
+        
         /// Session is resuming
         case resuming
-
+        
+        /// Session is paused
+        case paused
+        
+        /// Session is closing
+        case closing
+        
         /// Session is closed
         case closed
-
+        
     }
-
-    /**
-     Client session error.
-     */
-    public enum SessionError: Error {
-
-        /// Closed by caller.
-        case closedByCaller
-
-        /// Network is unavailable.
-        case networkUnavailable
-
-        /// Application did enter background.
-        case applicationDidEnterBackground
-
-        /// The opening operation is timed out.
-        case timedOut
-
-        /// Other error, like websocket error or LeanCloud error.
-        case error(Error)
-
-        init(event: Connection.Event) {
-            switch event {
-            case .disconnectInvoked:
-                self = .closedByCaller
-            case .appInBackground:
-                self = .applicationDidEnterBackground
-            case .networkNotReachable, .networkChanged:
-                self = .networkUnavailable
-            case .error(let error):
-                self = .error(error)
-            }
-        }
-
+    
+    public enum SessionOpenAction {
+        case force
+        case resume
     }
-
+    
     /// The client identifier.
     public let id: String
-
+    
     /// The client tag, which represents what kind of session that current client will open.
     /// For two sessions of one client with same tag, the later one will force to make previous one offline.
     public let tag: String?
-
+    
     /// The client options.
     public let options: Options
-
+    
     /// The application that the client belongs to.
     public let application: LCApplication
-
-    /// The custom server URL.
-    public let customServer: URL?
-
-    /// The client session state.
-    public var sessionState: SessionState = .closed
-
-    /// If session is closed by caller
-    private var isClosedByCaller = false
-
-    /// The incoming command of opening session.
-    private var openingSessionIncomingCommand: IMGenericCommand?
-
-    /// Should delegate session state.
-    private var shouldDelegateSessionState: Bool {
-        return synchronize(on: self) {
-            /* Only delegate session state after session did open. */
-            return openingSessionIncomingCommand != nil
-        }
-    }
-
+    
     /// The delegate object.
     public weak var delegate: LCClientDelegate?
-
+    
+    /// The dispatch queue on which the event about IM are called. Default is main.
+    public let eventQueue: DispatchQueue
+    
+    /// The custom server URL.
+    public let customServer: URL?
+    
+    /// The client session state.
+    public private(set) var sessionState: SessionState {
+        set(newValue) {
+            synchronize(on: self) {
+                self.underlyingSessionState = newValue
+            }
+        }
+        get {
+            return self.underlyingSessionState
+        }
+    }
+    
+    private var underlyingSessionState: SessionState = .closed
+    
     /// The client serial dispatch queue.
     private let serialDispatchQueue = DispatchQueue(
         label: "LeanCloud.ClientSerialDispatchQueue",
         qos: .userInteractive)
-
-    /// The timeout dispatch queue.
-    private let sessionTimeoutDispatchQueue = DispatchQueue(
-        label: "LeanCloud.ClientSessionTimeoutDispatchQueue",
-        qos: .userInteractive,
-        attributes: .concurrent)
-
+    
+    #if DEBUG
+    private let specificKey = DispatchSpecificKey<Int>()
+    // whatever random Int is OK.
+    private let specificValue: Int = Int.random(in: 1...999)
+    private var specificAssertion: Bool {
+        return self.specificValue == DispatchQueue.getSpecific(key: self.specificKey)
+    }
+    #else
+    private var specificAssertion: Bool {
+        return true
+    }
+    #endif
+    
     /// The session connection.
-    private lazy var connection = Connection(
-        application: application,
-        delegate: self,
-        lcimProtocol: options.lcimProtocol,
-        customRTMServer: customServer?.absoluteString,
-        delegateQueue: serialDispatchQueue,
-        isAutoReconnectionEnabled: false)
-
+    private let connection: Connection
+    
     /**
      Initialize client with identifier and tag.
-
+     
      - parameter id: The client identifier.
      - parameter tag: The client tag.
      - parameter options: The client options.
+     - parameter eventQueue: @see property `eventQueue`, default is main.
      - parameter customServer: The custom server URL for private deployment.
      - parameter application: The application that the client belongs to.
      */
@@ -176,238 +144,144 @@ public final class LCClient: NSObject {
         id: String,
         tag: String? = nil,
         options: Options = .default,
+        delegate: LCClientDelegate? = nil,
+        eventQueue: DispatchQueue = .main,
         customServer: URL? = nil,
         application: LCApplication = .default)
     {
+        #if DEBUG
+        serialDispatchQueue.setSpecific(key: specificKey, value: specificValue)
+        #endif
         self.id = id
         self.tag = tag
         self.options = options
+        self.delegate = delegate
+        self.eventQueue = eventQueue
         self.customServer = customServer
         self.application = application
+        self.connection = Connection(
+            application: application,
+            lcimProtocol: options.lcimProtocol,
+            delegateQueue: serialDispatchQueue,
+            customRTMServerURL: customServer)
     }
-
-    /// The opening completion.
+    
+    /// The incoming command of opening session.
+    private var sessionOpenedCommand: IMSessionCommand?
+    
+    /// Should delegate session state.
+    private var shouldDelegateSessionState: Bool {
+        assert(self.specificAssertion)
+        return sessionOpenedCommand != nil
+    }
+    
     private var openingCompletion: ((LCBooleanResult) -> Void)?
-
-    /// Timeout interval of opening completion.
-    private let openingCompletionTimeout: TimeInterval = 60
-
-    /// The timeout work item.
-    private var timeoutWorkItem: DispatchWorkItem?
-
-    /// A flag indicates whether opening session is timed out.
-    private var isTimedOut = false
-
-    /**
-     Call opening completion with result.
-
-     It will also reset the opening completion to ensure that it can be called only once.
-
-     - parameter result: The boolean result.
-     */
-    private func callOpeningCompletion(with result: LCBooleanResult) {
-        synchronize(on: self) {
-            guard let openingCompletion = openingCompletion else {
-                return
-            }
-
-            self.openingCompletion = nil
-
-            mainQueueAsync {
-                openingCompletion(result)
-            }
-        }
-    }
-
-    /**
-     Set timeout for opening completion.
-     */
-    private func setTimeoutForOpeningCompletion() {
-        if let workItem = timeoutWorkItem {
-            workItem.cancel()
-        }
-
-        let deadline: DispatchTime = .now() + openingCompletionTimeout
-
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let client = self else {
-                return
-            }
-            client.fireTimeoutForOpeningCompletion()
-        }
-
-        sessionTimeoutDispatchQueue.asyncAfter(deadline: deadline, execute: workItem)
-
-        timeoutWorkItem = workItem
-    }
-
-    /**
-     Cancel and remove timeout work item.
-     */
-    private func cancelAndRemoveTimeoutWorkItem() {
-        synchronize(on: self) {
-            guard let workItem = timeoutWorkItem else {
-                return
-            }
-
-            timeoutWorkItem = nil
-
-            workItem.cancel()
-        }
-    }
-
-    /**
-     Fire timeout for opening completion.
-     */
-    private func fireTimeoutForOpeningCompletion() {
-        synchronize(on: self) {
-            connection.setAutoReconnectionEnabled(with: false)
-
-            callOpeningCompletion(with: .failure(error: SessionError.timedOut))
-
-            timeoutWorkItem = nil
-
-            isTimedOut = true
-        }
-    }
-
-    /**
-     Reset auto-reconnection.
-     */
-    private func resetAutoReconnection() {
-        connection.setAutoReconnectionEnabled(with: options.isAutoReconnectionEnabled)
-    }
-
+    private var openingTimeoutWorkItem: DispatchWorkItem?
+    private var openingAction: SessionOpenAction?
+    
     /**
      Open a session to IM system.
-
+     
      A client cannot do anything before a session did open successfully.
-
+     
      - parameter completion: The completion handler.
      */
-    public func open(completion: @escaping (LCBooleanResult) -> Void) {
-        synchronize(on: self) {
-            guard openingCompletion == nil else {
-                let error = LCError(
-                    code: .inconsistency,
-                    reason: "Cannot open session before previous operation finish.")
-
-                mainQueueAsync {
+    public func open(action: SessionOpenAction = .force, timeout: TimeInterval = 60.0, completion: @escaping (LCBooleanResult) -> Void) {
+        self.serialDispatchQueue.async {
+            guard self.openingCompletion == nil && self.sessionOpenedCommand == nil else {
+                var reason: String = "cannot do repetitive operation."
+                if let _ = self.openingCompletion {
+                    reason = "In opening, \(reason)"
+                } else {
+                    reason = "Session did opened, \(reason)"
+                }
+                self.eventQueue.async {
+                    let error = LCError(code: .inconsistency, reason: reason)
                     completion(.failure(error: error))
                 }
-
                 return
             }
-
-            openingCompletion = completion
-
-            isClosedByCaller = false
-
-            openingSessionIncomingCommand = nil
-
-            isTimedOut = false
-
-            /* Enable auto-reconnection for opening WebSocket connection to send session command. */
-            connection.setAutoReconnectionEnabled(with: true)
-
-            /* Set timeout to ensure that completion handler can be called finally. */
-            cancelAndRemoveTimeoutWorkItem()
-            setTimeoutForOpeningCompletion()
-
-            /* Call completion handler directly if session is opened already.
-               Otherwise, try to connect and open session. */
-            switch sessionState {
-            case .opened:
-                callOpeningCompletion(with: .success)
-            default:
-                connection.connect()
+            
+            self.openingCompletion = completion
+            self.openingAction = action
+            
+            let timeoutWorkItem = DispatchWorkItem() { [weak self] in
+                guard let self = self, let openingCompletion = self.openingCompletion else {
+                    return
+                }
+                self.clearOpeningConfig()
+                let error = LCError(code: .commandTimeout, reason: "Session open operation timed out.")
+                self.handleSessionClosed(result: .failure(error: error), completion: openingCompletion)
             }
+            self.openingTimeoutWorkItem = timeoutWorkItem
+            self.serialDispatchQueue.asyncAfter(deadline: .now() + timeout, execute: timeoutWorkItem)
+            
+            /* Enable auto-reconnection for opening WebSocket connection to send session command. */
+            self.connection.delegate = self
+            self.connection.setAutoReconnectionEnabled(with: true)
+            self.connection.connect()
         }
     }
-
+    
     /**
-     Open a session to RTM server.
-
+     Close with completion handler.
+     
      - parameter completion: The completion handler.
      */
-    private func openSession(completion: @escaping (LCClient, Connection.CommandCallback.Result) -> Void) {
-        sendCommand(
-        constructor: { (client, command) in
-            command.cmd = .session
-            command.op = .open
-
-            var sessionCommand = IMSessionCommand()
-
-            sessionCommand.deviceToken = UUID().uuidString
-            sessionCommand.ua = HTTPClient.default.configuration.userAgent
-
-            command.sessionMessage = sessionCommand
-        },
-        completion: completion)
-    }
-
-    /**
-     Process the result of opening session.
-
-     - parameter result: The result of opening session.
-     */
-    private func processOpeningSessionResult(_ result: Connection.CommandCallback.Result) {
-        synchronize(on: self) {
-            if isTimedOut {
-                // If session is timed out, do nothing.
+    public func close(completion: @escaping (LCBooleanResult) -> Void) {
+        self.serialDispatchQueue.async {
+            guard self.sessionState == .opened else {
+                var reason: String
+                if self.sessionState == .closing {
+                    reason = "In closing, cannot do repetitive operation."
+                } else {
+                    reason = "Session not opened."
+                }
+                self.eventQueue.async {
+                    let error = LCError(code: .inconsistency, reason: reason)
+                    completion(.failure(error: error))
+                }
                 return
             }
-
-            cancelAndRemoveTimeoutWorkItem()
-
-            resetAutoReconnection()
-
-            switch result {
-            case .inCommand(let command):
-                processOpeningSessionIncomingCommand(command)
-
-                if updateSessionState(.opened) {
-                    if let delegate = delegate {
-                        mainQueueAsync {
-                            delegate.clientDidOpenSession(self)
-                        }
+            
+            self.sessionState = .closing
+            
+            var outCommand = IMGenericCommand()
+            outCommand.cmd = .session
+            outCommand.op = .close
+            outCommand.sessionMessage = IMSessionCommand()
+            
+            self.connection.send(command: outCommand) { [weak self] (result) in
+                guard let self = self else {
+                    return
+                }
+                switch result {
+                case .inCommand(let inCommand):
+                    if inCommand.cmd == .session && inCommand.op == .closed {
+                        self.handleSessionClosed(result: .success, completion: completion)
+                    } else {
+                        let error = LCError(code: .commandInvalid)
+                        self.handleSessionClosed(result: .failure(error: error), completion: completion)
+                    }
+                case .error(let error):
+                    self.eventQueue.async {
+                        completion(.failure(error: error))
                     }
                 }
-
-                callOpeningCompletion(with: .success)
-            case .error(let error):
-                let error = SessionError.error(error)
-
-                if updateSessionState(.closed) {
-                    if let delegate = delegate {
-                        mainQueueAsync {
-                            delegate.clientDidCloseSession(self, error: error)
-                        }
-                    }
-                }
-
-                callOpeningCompletion(with: .failure(error: error))
             }
         }
     }
+    
+}
 
-    /**
-     Process incoming command for opening session.
-
-     - parameter command: The opening session incoming command.
-     */
-    private func processOpeningSessionIncomingCommand(_ command: IMGenericCommand) {
-        synchronize(on: self) {
-            openingSessionIncomingCommand = command
-        }
-    }
-
+internal extension LCClient {
+    
     /**
      Enqueue serial task asynchronously.
-
+     
      - parameter task: The task to be enqueued.
      */
-    private func enqueueSerialTask(_ task: @escaping (LCClient) -> Void) {
+    func enqueueSerialTask(_ task: @escaping (LCClient) -> Void) {
         serialDispatchQueue.async { [weak self] in
             guard let client = self else {
                 return
@@ -415,32 +289,30 @@ public final class LCClient: NSObject {
             task(client)
         }
     }
-
+    
     /**
      Send a command to server side.
-
+     
      - parameter constructor: The command constructor.
      - parameter completion: The completion handler.
      */
-    private func sendCommand(
+    func sendCommand(
         constructor: @escaping (LCClient, inout IMGenericCommand) -> Void,
         completion: @escaping (LCClient, Connection.CommandCallback.Result) -> Void)
     {
         enqueueSerialTask { client in
+            
+            guard self.sessionState == .opened else {
+                let error = LCError(code: .clientNotOpen)
+                completion(client, .error(error))
+                return
+            }
+            
             var command = IMGenericCommand()
-
-            let application = client.application
-            let connection = client.connection
-
-            /*
-             Set common fields that every command will carry.
-             */
-            command.appID = application.id
-            command.peerID = client.id
-
+            
             constructor(client, &command)
-
-            connection.send(command: command) { [weak client] result in
+            
+            client.connection.send(command: command) { [weak client] result in
                 guard let client = client else {
                     return
                 }
@@ -448,182 +320,200 @@ public final class LCClient: NSObject {
             }
         }
     }
+    
+}
 
-    /*
-     Update session state.
-
-     - parameter sessionState: The new session state.
-     */
-    private func updateSessionState(_ sessionState: SessionState) -> Bool {
-        return synchronize(on: self) {
-            guard shouldDelegateSessionState else {
-                return false
-            }
-
-            // TODO: Validate State Transition
-
-            self.sessionState = sessionState
-
-            return true
+private extension LCClient {
+    
+    private func newOpenCommand() -> IMGenericCommand {
+        assert(self.specificAssertion)
+        var outCommand = IMGenericCommand()
+        outCommand.cmd = .session
+        outCommand.op = .open
+        outCommand.appID = self.application.id
+        outCommand.peerID = self.id
+        var sessionCommand = IMSessionCommand()
+        outCommand.sessionMessage = sessionCommand
+        #if os(iOS) || os(tvOS)
+        sessionCommand.deviceToken = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        #else
+        sessionCommand.deviceID = UUID().uuidString
+        #endif
+        sessionCommand.ua = HTTPClient.default.configuration.userAgent
+        if let tag: String = self.tag {
+            sessionCommand.tag = tag
         }
+        return outCommand
     }
-
-    /**
-     Close with completion handler.
-
-     - parameter completion: The completion handler.
-     */
-    public func close(completion: @escaping (LCBooleanResult) -> Void) {
-        sendCommand(
-        constructor: { (client, command) in
-            command.cmd = .session
-            command.op = .close
-        },
-        completion: { (client, result) in
-            client.processClosingSessionResult(result, completion: completion)
-        })
-    }
-
-    /**
-     Process closing session result.
-
-     - parameter result: The closing session result.
-     - parameter completion: The completion handler.
-     */
-    private func processClosingSessionResult(
-        _ result: Connection.CommandCallback.Result,
-        completion: @escaping (LCBooleanResult) -> Void)
-    {
-        switch result {
-        case .error(let error):
-            mainQueueAsync {
-                completion(.failure(error: error))
-            }
-        case .inCommand:
-            sessionDidCloseWithError(.closedByCaller)
-
-            mainQueueAsync {
-                completion(.success)
-            }
-        }
-    }
-
-    /**
-     Notify closed state with error.
-
-     - parameter error: The session error.
-     */
-    private func sessionDidCloseWithError(_ error: SessionError) {
-        synchronize(on: self) {
-            if isClosedByCaller {
-                return
-            }
-
-            if updateSessionState(.closed) {
-                if let delegate = delegate {
-                    mainQueueAsync {
-                        delegate.clientDidCloseSession(self, error: error)
+    
+    private func handleOpenCommandCallback(inCommand: IMGenericCommand, openingCompletion: ((LCBooleanResult) -> Void)?) {
+        assert(self.specificAssertion)
+        if inCommand.cmd == .session && inCommand.hasSessionMessage {
+            let sessionCommand: IMSessionCommand = inCommand.sessionMessage
+            if inCommand.op == .opened && sessionCommand.hasSt && sessionCommand.hasStTtl {
+                self.sessionOpenedCommand = sessionCommand
+                self.sessionState = .opened
+                self.eventQueue.async {
+                    if let completion = openingCompletion {
+                        completion(.success)
+                    } else {
+                        self.delegate?.client(didOpenSession: self)
                     }
                 }
+                return
+            } else if inCommand.op == .closed {
+                let code: Int = Int(sessionCommand.code)
+                let reason: String = sessionCommand.reason
+                let userInfo: LCError.UserInfo? = (sessionCommand.hasDetail ? ["detail" : sessionCommand.detail] : nil)
+                let error = LCError(code: code, reason: reason, userInfo: userInfo)
+                self.handleSessionClosed(result: .failure(error: error), completion: openingCompletion)
+                return
             }
-
-            switch error {
-            case .closedByCaller:
-                isClosedByCaller = true
-
-                openingSessionIncomingCommand = nil
-
-                /* Disable auto-reconnection if session is closed by caller. */
-                connection.setAutoReconnectionEnabled(with: false)
-            default:
-                break
+        }
+        let error = LCError(code: .commandInvalid)
+        self.handleSessionClosed(result: .failure(error: error), completion: openingCompletion)
+    }
+    
+    private func clearOpeningConfig() {
+        assert(self.specificAssertion)
+        self.openingTimeoutWorkItem?.cancel()
+        self.openingTimeoutWorkItem = nil
+        self.openingCompletion = nil
+        self.openingAction = nil
+    }
+    
+    private func handleSessionClosed(result: LCBooleanResult, completion: ((LCBooleanResult) -> Void)?) {
+        assert(self.specificAssertion)
+        self.connection.delegate = nil
+        self.connection.setAutoReconnectionEnabled(with: false)
+        self.connection.disconnect()
+        self.sessionOpenedCommand = nil
+        self.sessionState = .closed
+        self.eventQueue.async {
+            if let completion = completion {
+                completion(result)
+            } else if case let .failure(error) = result {
+                self.delegate?.client(self, didCloseSession: LCError(underlyingError: error))
             }
-
-            callOpeningCompletion(with: .failure(error: error))
         }
     }
-
+    
 }
 
 extension LCClient: ConnectionDelegate {
-
-    func connectionInConnecting(connection: Connection) {
-        synchronize(on: self) {
-            if isClosedByCaller {
-                return
+    
+    func connection(inConnecting connection: Connection) {
+        assert(self.specificAssertion)
+        guard shouldDelegateSessionState, self.sessionState != .resuming else {
+            return
+        }
+        self.sessionState = .resuming
+        self.eventQueue.async {
+            self.delegate?.client(didBecomeResumeSession: self)
+        }
+    }
+    
+    func connection(didConnect connection: Connection) {
+        assert(self.specificAssertion)
+        var openCommand: IMGenericCommand = self.newOpenCommand()
+        if let _ = self.openingCompletion, let openingAction = self.openingAction {
+            openCommand.sessionMessage.r = (openingAction == .resume)
+            self.connection.send(command: openCommand) { [weak self] (result) in
+                guard let self = self, let completion = self.openingCompletion else {
+                    return
+                }
+                switch result {
+                case .inCommand(let inCommand):
+                    self.clearOpeningConfig()
+                    self.handleOpenCommandCallback(inCommand: inCommand, openingCompletion: completion)
+                case .error(let error):
+                    // no need handle it, just log info.
+                    Logger.shared.debug(error)
+                }
             }
-            if updateSessionState(.resuming) {
-                if let delegate = delegate {
-                    mainQueueAsync {
-                        delegate.clientDidBecomeResumeSession(self)
-                    }
+        } else if let currentSessionOpenedCommand: IMSessionCommand = self.sessionOpenedCommand {
+            openCommand.sessionMessage.r = true
+            openCommand.sessionMessage.st = currentSessionOpenedCommand.st
+            self.connection.send(command: openCommand) { [weak self] (result) in
+                guard let self = self else {
+                    return
+                }
+                switch result {
+                case .inCommand(let inCommand):
+                    self.handleOpenCommandCallback(inCommand: inCommand, openingCompletion: nil)
+                case .error(let error):
+                    // no need handle it, just log info.
+                    Logger.shared.debug(error)
                 }
             }
         }
     }
-
-    func connectionDidConnect(connection: Connection) {
-        synchronize(on: self) {
-            if isClosedByCaller {
-                return
-            }
-            openSession { (client, result) in
-                client.processOpeningSessionResult(result)
+    
+    func connection(_ connection: Connection, didDisconnect error: LCError) {
+        assert(self.specificAssertion)
+        let routerError = LCError.malformedRTMRouterResponse
+        if error.code == routerError.code && error.reason == routerError.reason {
+            let openingCompletion = self.openingCompletion
+            self.clearOpeningConfig()
+            self.handleSessionClosed(result: .failure(error: error), completion: openingCompletion)
+        } else if self.shouldDelegateSessionState {
+            self.sessionState = .paused
+            self.eventQueue.async {
+                self.delegate?.client(self, didPauseSession: error)
             }
         }
     }
-
-    func connection(connection: Connection, didFailInConnecting event: Connection.Event) {
-        sessionDidCloseWithError(SessionError(event: event))
-    }
-
-    func connection(connection: Connection, didDisconnect event: Connection.Event) {
-        sessionDidCloseWithError(SessionError(event: event))
-    }
-
-    func connection(connection: Connection, didReceiveCommand inCommand: IMGenericCommand) {
+    
+    func connection(_ connection: Connection, didReceiveCommand inCommand: IMGenericCommand) {
+        assert(self.specificAssertion)
         // TODO: Process Command
     }
-
+    
 }
 
 public protocol LCClientDelegate: NSObjectProtocol {
-
+    
     /**
      Notify that client did open session.
-
+     
      - parameter client: The client who did open session.
      */
-    func clientDidOpenSession(_ client: LCClient)
-
+    func client(didOpenSession client: LCClient)
+    
     /**
      Notify that client did become resume session.
-
+     
      - parameter client: The client who did become resume session.
      */
-    func clientDidBecomeResumeSession(_ client: LCClient)
-
+    func client(didBecomeResumeSession client: LCClient)
+    
+    func client(_ client: LCClient, didPauseSession error: LCError)
+    
     /**
      Notify that client did close session.
-
+     
      - parameter client: The client who did close session.
      */
-    func clientDidCloseSession(_ client: LCClient, error: LCClient.SessionError)
-
+    func client(_ client: LCClient, didCloseSession error: LCError)
+    
 }
 
 extension LCClientDelegate {
-
-    func clientDidOpenSession(_ client: LCClient) {
+    
+    func client(didOpenSession client: LCClient) {
         /* Nop */
     }
-
-    func clientDidBecomeResumeSession(_ client: LCClient) {
+    
+    func client(didBecomeResumeSession client: LCClient) {
         /* Nop */
     }
-
-    func clientDidCloseSession(_ client: LCClient, error: LCClient.SessionError) {
+    
+    func client(_ client: LCClient, didPauseSession error: LCError) {
         /* Nop */
     }
-
+    
+    func client(_ client: LCClient, didCloseSession error: LCError) {
+        /* Nop */
+    }
+    
 }

--- a/Sources/IM/Client.swift
+++ b/Sources/IM/Client.swift
@@ -303,14 +303,15 @@ public final class LCClient: NSObject {
     public func close(completion: @escaping (LCBooleanResult) -> Void) {
         self.serialDispatchQueue.async {
             guard self.isSessionOpened else {
-                var reason: String
+                var error: LCError
                 if self.sessionState == .closing {
-                    reason = "In closing, cannot do repetitive operation."
+                    error = LCError(
+                        code: .inconsistency,
+                        reason: "In closing, cannot do repetitive operation.")
                 } else {
-                    reason = "Session not opened."
+                    error = LCError(code: .clientNotOpen)
                 }
                 self.eventQueue.async {
-                    let error = LCError(code: .inconsistency, reason: reason)
                     completion(.failure(error: error))
                 }
                 return

--- a/Sources/IM/Client.swift
+++ b/Sources/IM/Client.swift
@@ -104,7 +104,7 @@ public final class LCClient: NSObject {
     public let application: LCApplication
     
     /// Application's current installation
-    @objc internal var installation: LCInstallation
+    internal let installation: LCInstallation
     
     /// The delegate object.
     public weak var delegate: LCClientDelegate?
@@ -196,24 +196,24 @@ public final class LCClient: NSObject {
             delegateQueue: serialDispatchQueue,
             customRTMServerURL: customServer)
         super.init()
-        self.deviceTokenObservation = self.observe(
-            \.installation.deviceToken,
+        self.deviceTokenObservation = self.installation.observe(
+            \.deviceToken,
             options: [.old, .new, .initial]
-        ) { (client, change) in
+        ) { [weak self] (_, change) in
             let oldToken: String? = change.oldValue??.value
             let newToken: String? = change.newValue??.value
             guard let token: String = newToken, oldToken != newToken else {
                 return
             }
-            client.serialDispatchQueue.async {
-                guard client.currentDeviceToken != token else {
+            self?.serialDispatchQueue.async {
+                guard let self = self, self.currentDeviceToken != token else {
                     return
                 }
-                client.currentDeviceToken = token
-                guard client.isSessionOpened else {
+                self.currentDeviceToken = token
+                guard self.isSessionOpened else {
                     return
                 }
-                client.report(deviceToken: token)
+                self.report(deviceToken: token)
             }
         }
     }

--- a/Sources/IM/Client.swift
+++ b/Sources/IM/Client.swift
@@ -98,6 +98,9 @@ public final class LCClient: NSObject {
     /// The application that the client belongs to.
     public let application: LCApplication
     
+    /// Application's current installation
+    @objc internal var installation: LCInstallation
+    
     /// The delegate object.
     public weak var delegate: LCClientDelegate?
     
@@ -177,6 +180,7 @@ public final class LCClient: NSObject {
         self.eventQueue = eventQueue
         self.customServer = customServer
         self.application = application
+        self.installation = application.currentInstallation
         self.connection = Connection(
             application: application,
             lcimProtocol: options.lcimProtocol,
@@ -184,7 +188,7 @@ public final class LCClient: NSObject {
             customRTMServerURL: customServer)
         super.init()
         self.deviceTokenObservation = self.observe(
-            \.application.currentInstallation.deviceToken,
+            \.installation.deviceToken,
             options: [.old, .new, .initial]
         ) { (client, change) in
             let oldToken: String? = change.oldValue??.value

--- a/Sources/IM/Connection.swift
+++ b/Sources/IM/Connection.swift
@@ -48,6 +48,20 @@ class Connection {
         enum Result {
             case inCommand(IMGenericCommand)
             case error(LCError)
+            
+            var command: IMGenericCommand? {
+                switch self {
+                case .inCommand(let c): return c
+                case .error: return nil
+                }
+            }
+            
+            var error: LCError? {
+                switch self {
+                case .inCommand: return nil
+                case .error(let e): return e
+                }
+            }
         }
         
         let closure: ((Result) -> Void)

--- a/Sources/IM/Connection.swift
+++ b/Sources/IM/Connection.swift
@@ -14,29 +14,24 @@ import Alamofire
 
 protocol ConnectionDelegate: class {
     
-    /// Invoked when websocket is connecting server.
-    func connectionInConnecting(connection: Connection)
+    /// Invoked when websocket is connecting server or when geting RTM server.
+    /// @note This function maybe be called multiple times in single-try-connecting.
+    func connection(inConnecting connection: Connection)
     
     /// Invoked when websocket connected server.
-    func connectionDidConnect(connection: Connection)
-    
-    /// Invoked when encounter some can't-start-websocket-connecting event or websocket connecting failed.
-    ///
-    /// - Parameters:
-    ///   - event: @see Connection.Event
-    func connection(connection: Connection, didFailInConnecting event: Connection.Event)
+    func connection(didConnect connection: Connection)
     
     /// Invoked when the connected websocket encounter some should-disconnect event or other network error.
     ///
     /// - Parameters:
     ///   - event: @see Connection.Event
-    func connection(connection: Connection, didDisconnect event: Connection.Event)
+    func connection(_ connection: Connection, didDisconnect error: LCError)
     
     /// Invoked when the connected websocket receive direct-in-protobuf-command.
     ///
     /// - Parameters:
     ///   - inCommand: protobuf-command without serial ID.
-    func connection(connection: Connection, didReceiveCommand inCommand: IMGenericCommand)
+    func connection(_ connection: Connection, didReceiveCommand inCommand: IMGenericCommand)
 }
 
 class Connection {
@@ -45,21 +40,6 @@ class Connection {
     enum LCIMProtocol: String {
         case protobuf1 = "lc.protobuf2.1"
         case protobuf3 = "lc.protobuf2.3"
-    }
-    
-    /// Event for ConnectionDelegate
-    ///
-    /// - disconnectInvoked: The connected or in-connecting Connection-Instance was invoked disconnect().
-    /// - appInBackground: The connected or in-connecting Connection-Instance was disconencted due to APP enter background, or Connection-Instance can't start connecting.
-    /// - networkNotReachable: The connected or in-connecting Connection-Instance was disconencted due to network not reachable, or Connection-Instance can't start connecting.
-    /// - networkChanged: The connected or in-connecting Connection-Instance was disconencted due to network's primary interface changed.
-    /// - error: maybe LeanCloud error, websocket error or other network error.
-    enum Event {
-        case disconnectInvoked
-        case appInBackground
-        case networkNotReachable
-        case networkChanged
-        case error(Error)
     }
     
     /// private for Connection Class but internal for test, so should never use it.
@@ -189,7 +169,7 @@ class Connection {
     let application: LCApplication
     weak var delegate: ConnectionDelegate?
     let lcimProtocol: LCIMProtocol
-    let customRTMServer: String?
+    let customRTMServerURL: URL?
     let delegateQueue: DispatchQueue
     let commandTTL: TimeInterval
     
@@ -243,18 +223,17 @@ class Connection {
     ///
     /// - Parameters:
     ///   - application: LeanCloud Application, @see LCApplication.
-    ///   - delegate: @see ConnectionDelegate.
     ///   - lcimProtocol: @see LCIMProtocol.
-    ///   - customRTMServer: The custom RTM server, if set, Connection will ignore RTM Router, if not set, Connection will use the server return by RTM Router.
+    ///   - delegate: @see ConnectionDelegate.
     ///   - delegateQueue: The queue where ConnectionDelegate's fuctions and command's callback be invoked.
     ///   - commandTTL: Time-To-Live of command's callback.
+    ///   - customRTMServerURL: The custom RTM server, if set, Connection will ignore RTM Router, if not set, Connection will use the server return by RTM Router.
     init(application: LCApplication,
-         delegate: ConnectionDelegate,
          lcimProtocol: LCIMProtocol,
-         customRTMServer: String? = nil,
+         delegate: ConnectionDelegate? = nil,
          delegateQueue: DispatchQueue = .main,
          commandTTL: TimeInterval = 30.0,
-         isAutoReconnectionEnabled: Bool = true)
+         customRTMServerURL: URL? = nil)
     {
         #if DEBUG
         self.serialQueue.setSpecific(key: self.specificKey, value: self.specificValue)
@@ -262,10 +241,9 @@ class Connection {
         self.application = application
         self.delegate = delegate
         self.lcimProtocol = lcimProtocol
-        self.customRTMServer = customRTMServer
+        self.customRTMServerURL = customRTMServerURL
         self.delegateQueue = delegateQueue
         self.commandTTL = commandTTL
-        self.isAutoReconnectionEnabled = isAutoReconnectionEnabled
         
         self.rtmRouter = RTMRouter(application: application)
         
@@ -310,13 +288,14 @@ class Connection {
         self.afterWorkItemForReconnection?.cancel()
     }
     
-    /// Try connecting RTM server, if websocket exists and auto reconnection is enabled, then this action will be ignored.
+    /// Try connecting RTM server, if websocket exists, then this action will be ignored.
     func connect() {
         self.serialQueue.async {
-            if self.socket != nil && self.isAutoReconnectionEnabled {
+            guard self.socket == nil else {
+                // if socket exists, means in connecting or did connect.
                 return
             }
-            self.tryConnecting()
+            self.tryConnecting(forcing: true)
         }
     }
     
@@ -330,7 +309,7 @@ class Connection {
     /// Try close websocket, cancel timer and purge command callback.
     func disconnect() {
         self.serialQueue.async {
-            self.tryClearConnection(with: .disconnectInvoked)
+            self.tryClearConnection(with: LCError.closedByLocal)
         }
     }
     
@@ -400,9 +379,7 @@ extension Connection {
         self.previousAppState = newState
         switch (oldState, newState) {
         case (.background, .foreground):
-            if self.isAutoReconnectionEnabled {
-                self.tryConnecting()
-            }
+            self.tryConnecting()
         case (.foreground, .background):
             self.tryClearConnection(with: .appInBackground)
         default:
@@ -417,26 +394,24 @@ extension Connection {
         let oldStatus = self.previousReachabilityStatus
         self.previousReachabilityStatus = newStatus
         if oldStatus != .notReachable && newStatus == .notReachable {
-            self.tryClearConnection(with: .networkNotReachable)
+            self.tryClearConnection(with: LCError.networkUnavailable)
         } else if oldStatus != newStatus && newStatus != .notReachable {
-            self.tryClearConnection(with: .networkChanged)
-            if self.isAutoReconnectionEnabled {
-                self.tryConnecting()
-            }
+            self.tryClearConnection(with: LCError.networkChanged)
+            self.tryConnecting()
         }
     }
     #endif
     
-    private func checkIfCanDoConnecting() -> Event? {
+    private func checkIfCanDoConnecting() -> LCError? {
         assert(self.specificAssertion)
         #if os(iOS) || os(tvOS)
         guard self.previousAppState == .foreground else {
-            return Event.appInBackground
+            return LCError.appInBackground
         }
         #endif
         #if !os(watchOS)
         guard self.previousReachabilityStatus != .notReachable else {
-            return Event.networkNotReachable
+            return LCError.networkUnavailable
         }
         #endif
         return nil
@@ -460,8 +435,12 @@ extension Connection {
         return false
     }
     
-    private func tryConnecting() {
+    private func tryConnecting(forcing: Bool = false) {
         assert(self.specificAssertion)
+        guard self.isAutoReconnectionEnabled || forcing else {
+            // if auto-reconnection not enabled and not forcing, then not try connecting.
+            return
+        }
         if let workItem: DispatchWorkItem = self.afterWorkItemForReconnection {
             workItem.cancel()
             self.afterWorkItemForReconnection = nil
@@ -472,9 +451,9 @@ extension Connection {
                 // if socket exists, means in connecting or did connect.
                 return
             }
-            if let cannotEvent: Event = self.checkIfCanDoConnecting() {
+            if let cannotError: LCError = self.checkIfCanDoConnecting() {
                 self.delegateQueue.async {
-                    self.delegate?.connection(connection: self, didFailInConnecting: cannotEvent)
+                    self.delegate?.connection(self, didDisconnect: cannotError)
                 }
             } else {
                 switch result {
@@ -486,15 +465,15 @@ extension Connection {
                     socket.connect()
                     self.socket = socket
                     self.delegateQueue.async {
-                        self.delegate?.connectionInConnecting(connection: self)
+                        self.delegate?.connection(inConnecting: self)
                     }
                     Logger.shared.verbose("\(socket) connecting URL<\"\(url)\"> with protocol<\"\(self.lcimProtocol.rawValue)\">")
                 case .failure(error: let error):
                     Logger.shared.verbose("Get RTM server URL failed: \(error)")
                     self.delegateQueue.async {
-                        self.delegate?.connection(connection: self, didFailInConnecting: .error(error))
+                        self.delegate?.connection(self, didDisconnect: LCError(underlyingError: error))
                     }
-                    if (error as NSError).domain == NSURLErrorDomain && self.isAutoReconnectionEnabled {
+                    if (error as NSError).domain == NSURLErrorDomain {
                         self.tryConnecting()
                     }
                 }
@@ -502,7 +481,7 @@ extension Connection {
         }
     }
     
-    private func tryClearConnection(with event: Event) {
+    private func tryClearConnection(with error: LCError) {
         assert(self.specificAssertion)
         if let workItem: DispatchWorkItem = self.afterWorkItemForReconnection {
             workItem.cancel()
@@ -514,7 +493,7 @@ extension Connection {
             socket.disconnect()
             self.socket = nil
             self.delegateQueue.async {
-                self.delegate?.connection(connection: self, didDisconnect: event)
+                self.delegate?.connection(self, didDisconnect: error)
             }
         }
         if let timer: Timer = self.timer {
@@ -525,14 +504,14 @@ extension Connection {
     
     private func getRTMServer(_ callback: @escaping (LCGenericResult<URL>) -> Void) {
         assert(self.specificAssertion)
-        if let server: String = self.customRTMServer {
-            if let url = URL(string: server), url.scheme != nil {
-                callback(.success(value: url))
-            } else {
-                let error = LCError(code: .inconsistency, reason: "Custom RTM URL invalid")
-                callback(.failure(error: error))
-            }
+        if let serverURL: URL = self.customRTMServerURL {
+            callback(.success(value: serverURL))
         } else {
+            if self.socket == nil && self.checkIfCanDoConnecting() == nil {
+                self.delegateQueue.async {
+                    self.delegate?.connection(inConnecting: self)
+                }
+            }
             self.rtmRouter.route { (result: LCGenericResult<RTMRoutingTable>) in
                 self.serialQueue.async {
                     switch result {
@@ -564,6 +543,11 @@ extension Connection {
                 Logger.shared.error(error)
             }
             if self.isAutoReconnectionEnabled {
+                if self.socket == nil && self.checkIfCanDoConnecting() == nil {
+                    self.delegateQueue.async {
+                        self.delegate?.connection(inConnecting: self)
+                    }
+                }
                 let workItem = DispatchWorkItem() { [weak self] in
                     self?.afterWorkItemForReconnection = nil
                     self?.tryConnecting()
@@ -593,7 +577,7 @@ extension Connection: WebSocketDelegate, WebSocketPongDelegate {
             }
         }
         self.delegateQueue.async {
-            self.delegate?.connectionDidConnect(connection: self)
+            self.delegate?.connection(didConnect: self)
         }
     }
     
@@ -602,10 +586,10 @@ extension Connection: WebSocketDelegate, WebSocketPongDelegate {
         assert(self.socket === socket)
         Logger.shared.verbose("\(socket) disconnect with error: \(String(describing: error))")
         let isServerError: Bool = self.check(isServerError: error)
-        let disconnectError: Error = error ?? LCError(code: .connectionLost)
+        let disconnectError: LCError = LCError(underlyingError: error ?? LCError.closedByRemote)
         if self.timer != nil {
             // timer exists means the connected socket was disconnected.
-            self.tryClearConnection(with: .error(disconnectError))
+            self.tryClearConnection(with: disconnectError)
         } else {
             // timer not exists means connecting failed.
             self.socket?.delegate = nil
@@ -616,16 +600,14 @@ extension Connection: WebSocketDelegate, WebSocketPongDelegate {
                 // Should try Secondary Server and no need to notify delegator.
             } else {
                 self.delegateQueue.async {
-                    self.delegate?.connection(connection: self, didFailInConnecting: .error(disconnectError))
+                    self.delegate?.connection(self, didDisconnect: disconnectError)
                 }
             }
         }
         if isServerError {
             self.handleDisconnectForServerError()
         } else {
-            if self.isAutoReconnectionEnabled {
-                self.tryConnecting()
-            }
+            self.tryConnecting()
         }
     }
     
@@ -644,7 +626,7 @@ extension Connection: WebSocketDelegate, WebSocketPongDelegate {
             self.timer?.handle(callbackCommand: inCommand)
         } else {
             self.delegateQueue.async {
-                self.delegate?.connection(connection: self, didReceiveCommand: inCommand)
+                self.delegate?.connection(self, didReceiveCommand: inCommand)
             }
         }
     }
@@ -659,5 +641,34 @@ extension Connection: WebSocketDelegate, WebSocketPongDelegate {
     func websocketDidReceiveMessage(socket: WebSocketClient, text: String) {
         fatalError("should never be invoked.")
     }
+    
+}
+
+extension LCError {
+    
+    static let appInBackground: LCError = LCError(
+        code: .connectionLost,
+        reason: "Due to application did enter background, connection lost."
+    )
+    
+    static let networkUnavailable: LCError = LCError(
+        code: .connectionLost,
+        reason: "Due to network unavailable, connection lost."
+    )
+    
+    static let networkChanged: LCError = LCError(
+        code: .connectionLost,
+        reason: "Due to network interface did change, connection lost."
+    )
+    
+    static let closedByLocal: LCError = LCError(
+        code: .connectionLost,
+        reason: "Connection did close by local peer."
+    )
+    
+    static let closedByRemote: LCError = LCError(
+        code: .connectionLost,
+        reason: "Connection did close by remote peer."
+    )
     
 }


### PR DESCRIPTION
* LCClient 相关
    * 重构了和 Session open & close 相关的部分
    * 移除 SessionError，用 LCError 替代
    * 支持了「单设备登录」
    * 对应的单元测试
* Connection 移除 Error，用 LCError 替代

@tang3w 